### PR TITLE
Add audio-driven 3D backgrounds

### DIFF
--- a/docs/display_backgrounds_overview.md
+++ b/docs/display_backgrounds_overview.md
@@ -6,6 +6,10 @@
 | 02 | AudioReactiveBackground | ./prototype/frontend/src/components/AudioReactiveBackground.tsx | R3F/Three.js | `useFrame` | `audioAverageVolume` |
 | 03 | ModelViewer SpaceBackground | ./prototype/frontend/src/components/ModelViewer.tsx | R3F/Three.js | None | `showSpaceBackground` |
 | 04 | layout/SceneContainer Stars | ./prototype/frontend/src/components/layout/SceneContainer.tsx | R3F/Three.js | None | `showSpaceBackground` |
+| 05 | SpeechBackground | ./prototype/frontend/src/components/SpeechBackground.tsx | R3F/Three.js | `useFrame` | `audioAverageVolume` |
+| 06 | MusicBackground | ./prototype/frontend/src/components/MusicBackground.tsx | R3F/Three.js | `requestAnimationFrame` | `bgmIntensity` |
+| 07 | EffectBackground | ./prototype/frontend/src/components/EffectBackground.tsx | R3F/Three.js | `triggerEffect` | `effectTrigger` |
+| 08 | DynamicAudioBackgrounds | ./prototype/frontend/src/components/DynamicAudioBackgrounds.tsx | R3F/Three.js | None | composite |
 
 ```mermaid
 sequenceDiagram
@@ -31,11 +35,12 @@ sequenceDiagram
 
 ## 2. Event ↔ Background Matrix
 
-| Event | SceneContainer Stars | AudioReactiveBackground | ModelViewer SpaceBackground | layout/SceneContainer Stars |
-|-------|---------------------|-------------------------|----------------------------|----------------------------|
-| `toggleBackground` | ✅ | ❌ | ✅ | ✅ |
-| `audioAverageVolume` | ❌ | ✅ | ❌ | ❌ |
-| `emotionalTrajectory` | ❌ | ❌ | ❌ | ❌ |
+| Event | SceneContainer Stars | AudioReactiveBackground | ModelViewer SpaceBackground | layout/SceneContainer Stars | SpeechBackground | MusicBackground | EffectBackground |
+|-------|---------------------|-------------------------|----------------------------|----------------------------|----------------|----------------|----------------|
+| `toggleBackground` | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| `audioAverageVolume` | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| `bgmIntensity` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| `effectTrigger` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 
 ## 3. Integration Notes
 - `showSpaceBackground` is stored with other head model state, coupling scene toggling to model logic.

--- a/prototype/frontend/src/components/BackgroundSoundSystem.tsx
+++ b/prototype/frontend/src/components/BackgroundSoundSystem.tsx
@@ -1,6 +1,17 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useStore } from '../store';
 
+// utility to compute RMS from analyser data
+const getRms = (analyser: AnalyserNode, dataArray: Uint8Array) => {
+  analyser.getByteTimeDomainData(dataArray);
+  let sumSquares = 0;
+  for (let i = 0; i < dataArray.length; i++) {
+    const v = dataArray[i] / 128 - 1;
+    sumSquares += v * v;
+  }
+  return Math.sqrt(sumSquares / dataArray.length);
+};
+
 const BGM_PATH = '/audio/BGM/';
 const EFFECTS_PATH = '/audio/effects/';
 
@@ -15,11 +26,33 @@ const BackgroundSoundSystem: React.FC = () => {
   const effectSourceRef = useRef<AudioBufferSourceNode | null>(null);
   const bgmGainNodeRef = useRef<GainNode | null>(null);
   const effectGainNodeRef = useRef<GainNode | null>(null);
+  const bgmAnalyserRef = useRef<AnalyserNode | null>(null);
+  const bgmDataRef = useRef<Uint8Array | null>(null);
+  const bgmRafRef = useRef<number | null>(null);
 
   const bgmVolume = useStore((state) => state.bgmVolume);
   const effectVolume = useStore((state) => state.effectVolume);
+  const setBgmIntensity = useStore((state) => state.setBgmIntensity);
+  const triggerEffect = useStore((state) => state.triggerEffect);
 
   const [isUserInteracted, setIsUserInteracted] = useState(false);
+
+  const startBgmAnalysis = () => {
+    if (!bgmAnalyserRef.current || !bgmDataRef.current) return;
+    const loop = () => {
+      if (!bgmAnalyserRef.current || !bgmDataRef.current) return;
+      const rms = getRms(bgmAnalyserRef.current, bgmDataRef.current);
+      setBgmIntensity(rms);
+      bgmRafRef.current = requestAnimationFrame(loop);
+    };
+    bgmRafRef.current = requestAnimationFrame(loop);
+  };
+
+  const stopBgmAnalysis = () => {
+    if (bgmRafRef.current) cancelAnimationFrame(bgmRafRef.current);
+    bgmRafRef.current = null;
+    setBgmIntensity(0);
+  };
 
   // 更新音量設定
   useEffect(() => {
@@ -44,7 +77,12 @@ const BackgroundSoundSystem: React.FC = () => {
         // 建立 BGM 的 GainNode
         const bgmGain = context.createGain();
         bgmGain.gain.value = bgmVolume; // 預設 BGM 音量
-        bgmGain.connect(context.destination);
+        const bgmAnalyser = context.createAnalyser();
+        bgmAnalyser.fftSize = 256;
+        bgmGain.connect(bgmAnalyser);
+        bgmAnalyser.connect(context.destination);
+        bgmAnalyserRef.current = bgmAnalyser;
+        bgmDataRef.current = new Uint8Array(bgmAnalyser.frequencyBinCount);
         bgmGainNodeRef.current = bgmGain;
 
         // 建立 Effect 的 GainNode
@@ -123,6 +161,7 @@ const BackgroundSoundSystem: React.FC = () => {
         source.connect(bgmGainNodeRef.current);
         source.start();
         bgmSourceRef.current = source;
+        startBgmAnalysis();
 
         // 新增：當歌曲播放完畢時，再次呼叫 playBGM 以播放下一首
         source.onended = () => {
@@ -149,6 +188,7 @@ const BackgroundSoundSystem: React.FC = () => {
         bgmSourceRef.current.stop();
         bgmSourceRef.current.disconnect();
       }
+      stopBgmAnalysis();
     };
   }, [audioContext, isUserInteracted]); // 依賴 audioContext 和 isUserInteracted
 
@@ -189,6 +229,7 @@ const BackgroundSoundSystem: React.FC = () => {
         source.connect(effectGainNodeRef.current);
         source.start();
         effectSourceRef.current = source;
+        triggerEffect();
 
         // 音效播放完畢後，設定下一次隨機播放
         source.onended = scheduleNextEffect;

--- a/prototype/frontend/src/components/DynamicAudioBackgrounds.tsx
+++ b/prototype/frontend/src/components/DynamicAudioBackgrounds.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import SpeechBackground from './SpeechBackground';
+import MusicBackground from './MusicBackground';
+import EffectBackground from './EffectBackground';
+
+const DynamicAudioBackgrounds: React.FC = () => (
+  <>
+    <SpeechBackground />
+    <MusicBackground />
+    <EffectBackground />
+  </>
+);
+
+export default DynamicAudioBackgrounds;

--- a/prototype/frontend/src/components/EffectBackground.tsx
+++ b/prototype/frontend/src/components/EffectBackground.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { useStore } from '../store';
+
+interface Ripple {
+  id: number;
+  scale: number;
+  opacity: number;
+}
+
+const EffectBackground: React.FC = () => {
+  const trigger = useStore((s) => s.effectTrigger);
+  const [ripples, setRipples] = useState<Ripple[]>([]);
+
+  useEffect(() => {
+    if (trigger > 0) {
+      setRipples((prev) => [...prev, { id: trigger, scale: 0.1, opacity: 1 }]);
+    }
+  }, [trigger]);
+
+  useFrame(() => {
+    setRipples((prev) =>
+      prev
+        .map((r) => ({ ...r, scale: r.scale + 0.05, opacity: r.opacity - 0.02 }))
+        .filter((r) => r.opacity > 0)
+    );
+  });
+
+  return (
+    <>
+      {ripples.map((r) => (
+        <mesh key={r.id} scale={r.scale} position={[0, 0, -5]}>
+          <ringGeometry args={[0.5, 0.6, 32]} />
+          <meshBasicMaterial transparent color={0x88ffff} opacity={r.opacity} />
+        </mesh>
+      ))}
+    </>
+  );
+};
+
+export default EffectBackground;

--- a/prototype/frontend/src/components/MusicBackground.tsx
+++ b/prototype/frontend/src/components/MusicBackground.tsx
@@ -1,0 +1,24 @@
+import React, { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { useStore } from '../store';
+import * as THREE from 'three';
+
+const MusicBackground: React.FC = () => {
+  const meshRef = useRef<THREE.Mesh>(null);
+  const bgmIntensity = useStore((s) => s.bgmIntensity);
+
+  useFrame(() => {
+    if (meshRef.current) {
+      meshRef.current.rotation.z += 0.001 + bgmIntensity * 0.02;
+    }
+  });
+
+  return (
+    <mesh ref={meshRef} position={[0, 0, -10]}>
+      <torusKnotGeometry args={[3, 1, 100, 16]} />
+      <meshStandardMaterial color={0x222244} emissive={0x222244} emissiveIntensity={0.5 + bgmIntensity} />
+    </mesh>
+  );
+};
+
+export default MusicBackground;

--- a/prototype/frontend/src/components/SceneContainer.tsx
+++ b/prototype/frontend/src/components/SceneContainer.tsx
@@ -3,7 +3,7 @@ import { Canvas } from '@react-three/fiber';
 import { OrbitControls, Stars } from '@react-three/drei';
 import { HeadModel } from './HeadModel';
 import BodyModel from './BodyModel';
-import { AudioReactiveBackground } from './AudioReactiveBackground';
+import DynamicAudioBackgrounds from './DynamicAudioBackgrounds';
 
 interface SceneContainerProps {
   headModelUrl: string;
@@ -25,8 +25,10 @@ const SceneContainer: React.FC<SceneContainerProps> = ({
       camera={{ position: [0, 0.5, 3], fov: 50 }}
       style={{ background: showSpaceBackground ? '#000010' : '#111a21' }}
     >
-      {showSpaceBackground && <Stars radius={100} depth={50} count={5000} factor={4} saturation={0} fade speed={1} />}
-      <AudioReactiveBackground />
+      {showSpaceBackground && (
+        <Stars radius={100} depth={50} count={5000} factor={4} saturation={0} fade speed={1} />
+      )}
+      <DynamicAudioBackgrounds />
       <ambientLight intensity={0.5} />
       <directionalLight 
         position={[10, 10, 5]} 

--- a/prototype/frontend/src/components/SpeechBackground.tsx
+++ b/prototype/frontend/src/components/SpeechBackground.tsx
@@ -1,0 +1,32 @@
+import React, { useRef } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import { useStore } from '../store';
+import * as THREE from 'three';
+
+const SpeechBackground: React.FC = () => {
+  const meshRef = useRef<THREE.Mesh>(null);
+  const materialRef = useRef<THREE.MeshStandardMaterial>(null);
+  const { viewport } = useThree();
+  const audioAverageVolume = useStore((state) => state.audioAverageVolume);
+
+  useFrame(() => {
+    if (materialRef.current) {
+      const baseColor = new THREE.Color(0x111133);
+      materialRef.current.emissive.set(baseColor);
+      const sensitivity = 10.0;
+      let intensity = Math.pow(audioAverageVolume * sensitivity, 1.5);
+      const current = materialRef.current.emissiveIntensity;
+      intensity = THREE.MathUtils.lerp(current, intensity, 0.15);
+      materialRef.current.emissiveIntensity = Math.max(0.05, intensity);
+    }
+  });
+
+  return (
+    <mesh ref={meshRef} position={[0, 0, -5]}>
+      <planeGeometry args={[viewport.width * 1.5, viewport.height * 1.5]} />
+      <meshStandardMaterial ref={materialRef} color={0x050510} emissive={0x111133} emissiveIntensity={0.1} metalness={0} roughness={1} />
+    </mesh>
+  );
+};
+
+export default SpeechBackground;

--- a/prototype/frontend/src/components/__tests__/AudioBackgrounds.test.tsx
+++ b/prototype/frontend/src/components/__tests__/AudioBackgrounds.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import DynamicAudioBackgrounds from '../DynamicAudioBackgrounds';
+import { Canvas } from '@react-three/fiber';
+
+test('render dynamic audio backgrounds without crashing', () => {
+  render(
+    <Canvas>
+      <DynamicAudioBackgrounds />
+    </Canvas>
+  );
+});

--- a/prototype/frontend/src/store/index.ts
+++ b/prototype/frontend/src/store/index.ts
@@ -8,11 +8,20 @@ import { AppSlice, createAppSlice } from './slices/appSlice';
 import { MediaSlice, createMediaSlice } from './slices/mediaSlice';
 import { BodySlice, createBodySlice } from './slices/bodySlice';
 import { AudioSettingsSlice, createAudioSettingsSlice } from './slices/audioSettingsSlice';
+import { BackgroundAudioSlice, createBackgroundAudioSlice } from './slices/backgroundAudioSlice';
 // import { EmotionSlice, createEmotionSlice } from './slices/emotionSlice';
 // import { AudioSlice, createAudioSlice } from './slices/audioSlice';
 
 // 合併所有 slice 類型為最終 Store 類型
-export type Store = WebSocketSlice & ChatSlice & HeadSlice & AppSlice & MediaSlice & BodySlice & AudioSettingsSlice;
+export type Store =
+  WebSocketSlice &
+  ChatSlice &
+  HeadSlice &
+  AppSlice &
+  MediaSlice &
+  BodySlice &
+  AudioSettingsSlice &
+  BackgroundAudioSlice;
 
 // 創建 Zustand Store
 export const useStore = create<Store>()(
@@ -25,6 +34,7 @@ export const useStore = create<Store>()(
       ...createMediaSlice(set, get, api),
       ...createBodySlice(set, get, api),
       ...createAudioSettingsSlice(set, get, api),
+      ...createBackgroundAudioSlice(set, get, api),
     }),
     { name: 'AppStore' } // Optional: Name for Redux DevTools
   )

--- a/prototype/frontend/src/store/slices/backgroundAudioSlice.ts
+++ b/prototype/frontend/src/store/slices/backgroundAudioSlice.ts
@@ -1,0 +1,17 @@
+import { StateCreator } from 'zustand';
+
+export interface BackgroundAudioSlice {
+  bgmIntensity: number;
+  effectTrigger: number;
+  setBgmIntensity: (value: number) => void;
+  triggerEffect: () => void;
+}
+
+export const createBackgroundAudioSlice: StateCreator<BackgroundAudioSlice> = (
+  set
+) => ({
+  bgmIntensity: 0,
+  effectTrigger: 0,
+  setBgmIntensity: (value) => set({ bgmIntensity: value }),
+  triggerEffect: () => set((state) => ({ effectTrigger: state.effectTrigger + 1 })),
+});


### PR DESCRIPTION
## Summary
- create `SpeechBackground`, `MusicBackground`, `EffectBackground`
- combine new components with `DynamicAudioBackgrounds`
- drive new backgrounds from `BackgroundSoundSystem` via new `backgroundAudioSlice`
- render `DynamicAudioBackgrounds` from `SceneContainer`
- document all backgrounds
- add a simple test case

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `pytest -q` *(fails: command not found)*
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: cannot reach npm registry)*