### PR TITLE
Add live speech text background

### DIFF
--- a/prototype/frontend/src/components/SpeechBackground.tsx
+++ b/prototype/frontend/src/components/SpeechBackground.tsx
@@ -1,13 +1,27 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
+import { Text } from '@react-three/drei';
 import { useStore } from '../store';
 import * as THREE from 'three';
 
+// Renders a plane that reacts to audio volume and displays the latest
+// speech text from the chat stream as a large floating caption.
 const SpeechBackground: React.FC = () => {
   const meshRef = useRef<THREE.Mesh>(null);
   const materialRef = useRef<THREE.MeshStandardMaterial>(null);
   const { viewport } = useThree();
   const audioAverageVolume = useStore((state) => state.audioAverageVolume);
+  const speechText = useStore((state) => state.speechText);
+
+  // Local state with small debounce to avoid flicker when rapid
+  // updates arrive from the WebSocket/chat service.
+  const [displayText, setDisplayText] = useState('');
+
+  // Update displayed text when store changes
+  useEffect(() => {
+    const t = setTimeout(() => setDisplayText(speechText), 100);
+    return () => clearTimeout(t);
+  }, [speechText]);
 
   useFrame(() => {
     if (materialRef.current) {
@@ -22,10 +36,30 @@ const SpeechBackground: React.FC = () => {
   });
 
   return (
-    <mesh ref={meshRef} position={[0, 0, -15]}>
-      <planeGeometry args={[viewport.width * 1.5, viewport.height * 1.5]} />
-      <meshStandardMaterial ref={materialRef} color={0x050510} emissive={0x111133} emissiveIntensity={0.1} metalness={0} roughness={1} />
-    </mesh>
+    <group position={[0, 0, -15]}>
+      <mesh ref={meshRef}>
+        <planeGeometry args={[viewport.width * 1.5, viewport.height * 1.5]} />
+        <meshStandardMaterial
+          ref={materialRef}
+          color={0x050510}
+          emissive={0x111133}
+          emissiveIntensity={0.1}
+          metalness={0}
+          roughness={1}
+        />
+      </mesh>
+      {displayText && (
+        <Text
+          position={[0, 0, 0.1]}
+          fontSize={viewport.width / 10}
+          color="white"
+          anchorX="center"
+          anchorY="middle"
+        >
+          {displayText}
+        </Text>
+      )}
+    </group>
   );
 };
 

--- a/prototype/frontend/src/components/__tests__/SpeechBackground.test.tsx
+++ b/prototype/frontend/src/components/__tests__/SpeechBackground.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react';
+import { Canvas } from '@react-three/fiber';
+import { act } from 'react-dom/test-utils';
+import SpeechBackground from '../SpeechBackground';
+import { useStore } from '../../store';
+
+test('updates speech text from store', () => {
+  render(
+    <Canvas>
+      <SpeechBackground />
+    </Canvas>
+  );
+
+  act(() => {
+    useStore.getState().setSpeechText('hello');
+  });
+
+  expect(useStore.getState().speechText).toBe('hello');
+});

--- a/prototype/frontend/src/services/ChatService.ts
+++ b/prototype/frontend/src/services/ChatService.ts
@@ -102,7 +102,12 @@ class ChatService {
       
       // 更新最近消息（用於顯示情緒等）
       useStore.getState().setLastJsonMessage(data);
-      
+
+      // 將目前的語音文字存入 Zustand，供背景顯示
+      if (message.role === 'bot') {
+        useStore.getState().setSpeechText(message.content);
+      }
+
       this.addMessage(message);
       
       // 如果消息包含音頻URL且不是用戶發送的消息，播放語音

--- a/prototype/frontend/src/store/index.ts
+++ b/prototype/frontend/src/store/index.ts
@@ -9,6 +9,7 @@ import { MediaSlice, createMediaSlice } from './slices/mediaSlice';
 import { BodySlice, createBodySlice } from './slices/bodySlice';
 import { AudioSettingsSlice, createAudioSettingsSlice } from './slices/audioSettingsSlice';
 import { BackgroundAudioSlice, createBackgroundAudioSlice } from './slices/backgroundAudioSlice';
+import { SpeechTextSlice, createSpeechTextSlice } from './slices/speechTextSlice';
 // import { EmotionSlice, createEmotionSlice } from './slices/emotionSlice';
 // import { AudioSlice, createAudioSlice } from './slices/audioSlice';
 
@@ -21,7 +22,8 @@ export type Store =
   MediaSlice &
   BodySlice &
   AudioSettingsSlice &
-  BackgroundAudioSlice;
+  BackgroundAudioSlice &
+  SpeechTextSlice;
 
 // 創建 Zustand Store
 export const useStore = create<Store>()(
@@ -35,6 +37,7 @@ export const useStore = create<Store>()(
       ...createBodySlice(set, get, api),
       ...createAudioSettingsSlice(set, get, api),
       ...createBackgroundAudioSlice(set, get, api),
+      ...createSpeechTextSlice(set, get, api),
     }),
     { name: 'AppStore' } // Optional: Name for Redux DevTools
   )

--- a/prototype/frontend/src/store/slices/speechTextSlice.ts
+++ b/prototype/frontend/src/store/slices/speechTextSlice.ts
@@ -1,0 +1,11 @@
+import { StateCreator } from 'zustand';
+
+export interface SpeechTextSlice {
+  speechText: string;
+  setSpeechText: (text: string) => void;
+}
+
+export const createSpeechTextSlice: StateCreator<SpeechTextSlice> = (set) => ({
+  speechText: '',
+  setSpeechText: (text) => set({ speechText: text }),
+});


### PR DESCRIPTION
## Summary
- display current speech text in `SpeechBackground`
- add Zustand slice `speechTextSlice`
- push speech text from `ChatService`
- expose speech text slice in store
- test updating speech text state

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: react-scripts not found)*