### PR TITLE
Implement audio playback handshake and queue

### DIFF
--- a/prototype/backend/api/endpoints/websocket.py
+++ b/prototype/backend/api/endpoints/websocket.py
@@ -174,6 +174,37 @@ async def websocket_endpoint(websocket: WebSocket):
     speaking_state = SpeakingState.IDLE  # 當前語音狀態
     current_audio_task: Optional[asyncio.Task] = None  # <-- 確保類型提示和初始值
     # --- 結束修改 ---
+
+    # --- 新增：前端音頻播放握手 ---
+    audio_send_queue: Deque[Dict[str, Any]] = deque()
+    awaiting_playback_ack: Optional[str] = None
+
+    async def enqueue_audio_clip(clip: Dict[str, Any]):
+        """加入待發送音頻片段並嘗試發送"""
+        audio_send_queue.append(clip)
+        await try_send_next_audio_clip()
+
+    async def try_send_next_audio_clip():
+        nonlocal awaiting_playback_ack
+        if awaiting_playback_ack or not audio_send_queue:
+            return
+        clip = audio_send_queue[0]
+        await websocket.send_json({
+            "type": "play-audio",
+            "id": clip.get("id"),
+            "url": clip.get("url"),
+            "interrupt": clip.get("interrupt", False),
+        })
+        awaiting_playback_ack = clip.get("id")
+
+    async def handle_playback_ack(ack_id: str):
+        nonlocal awaiting_playback_ack
+        if awaiting_playback_ack and ack_id == awaiting_playback_ack:
+            audio_send_queue.popleft()
+            awaiting_playback_ack = None
+            await try_send_next_audio_clip()
+
+    # --- 結束新增 ---
     
     user_responded = False
 
@@ -418,6 +449,12 @@ async def websocket_endpoint(websocket: WebSocket):
                 "type": "chat-message",
                 "message": bot_message
             })
+
+            if bot_message.get("audioUrl"):
+                await enqueue_audio_clip({
+                    "id": bot_message["id"],
+                    "url": bot_message["audioUrl"],
+                })
             
             # 發送情緒軌跡（如果有）
             emotional_keyframes = ai_result.get("emotional_keyframes")
@@ -602,6 +639,12 @@ async def websocket_endpoint(websocket: WebSocket):
             
             await websocket.send_json({"type": "chat-message", "message": bot_message})
 
+            if bot_message.get("audioUrl"):
+                await enqueue_audio_clip({
+                    "id": bot_message["id"],
+                    "url": bot_message["audioUrl"],
+                })
+
             emotional_keyframes = ai_result.get("emotional_keyframes")
             if emotional_keyframes:
                 await websocket.send_json({
@@ -700,8 +743,11 @@ async def websocket_endpoint(websocket: WebSocket):
             # 將用戶消息加入隊列
             message = json.loads(data)
             message_type = message.get("type")
-            
-            if message_type == "message" or message_type == "chat-message":
+
+            if message_type == "playback_ack":
+                ack_id = message.get("id")
+                await handle_playback_ack(ack_id)
+            elif message_type == "message" or message_type == "chat-message":
                 content = message.get("content", message.get("message", ""))
                 if content:
                     # 更新活動時間戳

--- a/prototype/frontend/src/services/ChatService.ts
+++ b/prototype/frontend/src/services/ChatService.ts
@@ -28,6 +28,9 @@ class ChatService {
   private static instance: ChatService;
   private websocket: WebSocketService;
   private audioService: AudioService;
+  private playbackQueue: { id: string; url: string; interrupt?: boolean }[] = [];
+  private currentClip: { id: string; url: string } | null = null;
+  private waitingForAck = false;
   // ---> 添加一個映射來存儲每個請求的開始時間 <---
   private messageTimestamps: Map<string, number> = new Map();
   
@@ -44,9 +47,38 @@ class ChatService {
     // 初始化相關服務
     this.websocket = WebSocketService.getInstance();
     this.audioService = AudioService.getInstance();
-    
+
     // 註冊 WebSocket 消息處理器
     this.setupMessageHandlers();
+  }
+
+  private enqueueAudioClip(clip: { id: string; url: string; interrupt?: boolean }): void {
+    if (clip.interrupt) {
+      this.audioService.stopPlayback();
+      this.playbackQueue = [];
+      this.currentClip = null;
+      this.waitingForAck = false;
+    }
+    this.playbackQueue.push(clip);
+    this.processPlaybackQueue();
+  }
+
+  private async processPlaybackQueue(): Promise<void> {
+    if (this.currentClip || this.waitingForAck) return;
+    const clip = this.playbackQueue.shift();
+    if (!clip) return;
+    this.currentClip = { id: clip.id, url: clip.url };
+    this.waitingForAck = true;
+    try {
+      await this.audioService.playAudio(clip.url);
+    } catch (err) {
+      logger.error('音頻播放失敗', LogCategory.CHAT, err);
+    } finally {
+      this.websocket.sendMessage({ type: 'playback_ack', id: clip.id });
+      this.currentClip = null;
+      this.waitingForAck = false;
+      this.processPlaybackQueue();
+    }
   }
   
   // 設置 WebSocket 消息處理器
@@ -110,32 +142,16 @@ class ChatService {
 
       this.addMessage(message);
       
-      // 如果消息包含音頻URL且不是用戶發送的消息，播放語音
       if (message.audioUrl && message.role === 'bot') {
-        logger.info('播放消息語音:', LogCategory.CHAT, message.audioUrl);
-        
-        // 構建完整的音頻URL
         const fullAudioUrl = `${API_BASE_URL}${message.audioUrl}`;
-        logger.info('完整音頻URL:', LogCategory.CHAT, fullAudioUrl);
-        
-        // --- 修改播放邏輯：先獲取 Blob 再播放 ---
-        fetch(fullAudioUrl)
-          .then(response => {
-            if (!response.ok) {
-              throw new Error(`無法獲取音頻文件: ${response.statusText}`);
-            }
-            return response.blob(); // 將響應轉換為 Blob
-          })
-          .then(audioBlob => {
-            logger.info('成功獲取音頻 Blob，開始播放', LogCategory.CHAT);
-            this.audioService.playAudio(audioBlob); // <--- 播放 Blob
-          })
-          .catch(error => {
-            logger.error('獲取或播放音頻時出錯:', LogCategory.CHAT, error);
-            // 可選：顯示錯誤給用戶或嘗試播放 URL 作為備用
-            // this.audioService.playAudio(fullAudioUrl); 
-          });
-        // --- 修改結束 ---
+        this.enqueueAudioClip({ id: message.id, url: fullAudioUrl });
+      }
+    });
+
+    this.websocket.registerHandler('play-audio', (data: any) => {
+      if (data && data.url && data.id) {
+        const fullUrl = `${API_BASE_URL}${data.url}`;
+        this.enqueueAudioClip({ id: data.id, url: fullUrl, interrupt: data.interrupt });
       }
     });
     


### PR DESCRIPTION
## Summary
- implement playback handshake in backend websocket endpoint
- add audio clip queue on frontend ChatService
- send ACK from frontend after playback finish

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest` *(fails: command not found)*
- `npx markdownlint "**/*.md" --ignore node_modules`