### PR TITLE
Fix chat typing sync and clean backend audio queue

### DIFF
--- a/prototype/backend/api/endpoints/websocket.py
+++ b/prototype/backend/api/endpoints/websocket.py
@@ -179,14 +179,26 @@ async def websocket_endpoint(websocket: WebSocket):
     audio_send_queue: Deque[Dict[str, Any]] = deque()
     awaiting_playback_ack: Optional[str] = None
 
+    async def cleanup_audio_queue():
+        """Remove stale audio clips waiting too long in the queue."""
+        STALE_SECONDS = 30
+        now = datetime.utcnow()
+        while audio_send_queue and (now - audio_send_queue[0].get("timestamp", now)).total_seconds() > STALE_SECONDS:
+            stale = audio_send_queue.popleft()
+            logger.info(f"Removed stale audio clip {stale.get('id')}")
+
     async def enqueue_audio_clip(clip: Dict[str, Any]):
         """加入待發送音頻片段並嘗試發送"""
+        clip["timestamp"] = datetime.utcnow()
         audio_send_queue.append(clip)
         await try_send_next_audio_clip()
 
     async def try_send_next_audio_clip():
         nonlocal awaiting_playback_ack
         if awaiting_playback_ack or not audio_send_queue:
+            return
+        await cleanup_audio_queue()
+        if not audio_send_queue:
             return
         clip = audio_send_queue[0]
         await websocket.send_json({

--- a/prototype/frontend/src/App.tsx
+++ b/prototype/frontend/src/App.tsx
@@ -375,13 +375,21 @@ function App() {
               isTyping: true, 
               timestamp: new Date().toISOString(),
               speechDuration: speechDurationForTypingEffect, 
+              // 添加音頻URL作為消息的一部分，但不在這裡播放
+              // ChatService 會負責處理音頻播放
+              audioUrl: result.audio ? `data:audio/mp3;base64,${result.audio}` : undefined
             };
             addChatMessage(botResponseMessage);
 
+            // 注意：不要在這裡播放音頻
+            // ChatService 將根據 audioUrl 自動處理播放
+            // 這段代碼可能是導致重複播放的原因
+            /*
             if (result.audio) { 
               logger.info(`[App] Playing bot audio.`, LogCategory.GENERAL);
               AudioService.getInstance().playAudio(`data:audio/mp3;base64,${result.audio}`);
             }
+            */
           }
 
         } else if (result && !result.success) {

--- a/prototype/frontend/src/services/ChatService.ts
+++ b/prototype/frontend/src/services/ChatService.ts
@@ -69,6 +69,14 @@ class ChatService {
     if (!clip) return;
     this.currentClip = { id: clip.id, url: clip.url };
     this.waitingForAck = true;
+    // 在播放開始前觸發文字顯示並設置大螢幕文本
+    const msg = useStore.getState().messages.find(m => m.id === clip.id);
+    if (msg) {
+      useStore.getState().updateMessage(clip.id, { isTyping: true });
+      if (msg.role === 'bot') {
+        useStore.getState().setSpeechText(msg.content);
+      }
+    }
     try {
       await this.audioService.playAudio(clip.url);
     } catch (err) {
@@ -114,9 +122,9 @@ class ChatService {
       // 如果是機器人消息並且不是錯誤消息，添加打字機效果
       if (message.role === 'bot' && !message.isError) {
         const content = message.content;
-        
-        // 添加打字機效果屬性
-        message.isTyping = true;
+
+        // 僅在無音頻時立即開始打字效果，否則在播放時再啟動
+        message.isTyping = !message.audioUrl;
         message.fullContent = content;
         
         // 從消息中提取語音持續時間（如果有）
@@ -135,11 +143,6 @@ class ChatService {
       
       // 更新最近消息（用於顯示情緒等）
       useStore.getState().setLastJsonMessage(data);
-
-      // 將目前的語音文字存入 Zustand，供背景顯示
-      if (message.role === 'bot') {
-        useStore.getState().setSpeechText(message.content);
-      }
 
       this.addMessage(message);
       

--- a/prototype/frontend/src/services/ChatService.ts
+++ b/prototype/frontend/src/services/ChatService.ts
@@ -147,7 +147,12 @@ class ChatService {
       if (message.audioUrl && message.role === 'bot') {
         // 添加一個小延遲讓打字機效果先開始
         setTimeout(() => {
-          const fullAudioUrl = `${API_BASE_URL}${message.audioUrl}`;
+          // 檢查 audioUrl 格式，如果是 base64 格式則直接使用，否則拼接 API_BASE_URL
+          const fullAudioUrl = message.audioUrl.startsWith('data:') 
+            ? message.audioUrl 
+            : `${API_BASE_URL}${message.audioUrl}`;
+          
+          logger.info(`播放音頻: ${message.audioUrl.startsWith('data:') ? '[Base64 音頻]' : fullAudioUrl}`, LogCategory.CHAT);
           this.enqueueAudioClip({ id: message.id, url: fullAudioUrl });
         }, 50);
       }

--- a/prototype/frontend/src/store/slices/chatSlice.ts
+++ b/prototype/frontend/src/store/slices/chatSlice.ts
@@ -36,6 +36,7 @@ export interface ChatSlice {
   setProcessing: (processing: boolean) => void;
   setEmotion: (emotion: string, confidence: number) => void;
   toggleChatWindow: () => void;
+  updateMessage: (id: string, payload: Partial<ChatMessage>) => void;
 }
 
 // 創建 Chat Slice
@@ -60,6 +61,12 @@ export const createChatSlice: StateCreator<ChatSlice> = (set) => ({
   setEmotion: (emotion, confidence) => set({
     currentEmotion: { emotion, confidence }
   }),
-  
+
   toggleChatWindow: () => set((state) => ({ isChatWindowVisible: !state.isChatWindowVisible })),
-}); 
+
+  updateMessage: (id, payload) => set((state) => ({
+    messages: state.messages.map((m) =>
+      m.id === id ? { ...m, ...payload } : m
+    )
+  })),
+});


### PR DESCRIPTION
## Summary
- delay chat typing until its audio is played so text matches speech
- update messages in store via new `updateMessage` method
- drop stale audio clips on the server to keep the playback queue clean

## Testing
- `npx markdownlint "**/*.md" --ignore node_modules`
- `npm test --silent` *(fails: react-scripts not found)*
- `pytest` *(fails: command not found)*