### PR TITLE
Add dynamic Moire shader

### DIFF
--- a/docs/frontend/moire_shader.md
+++ b/docs/frontend/moire_shader.md
@@ -1,0 +1,20 @@
+# Moiré Shader Effect
+
+The `MoireShaderMaterial` component overlays a transparent Moiré interference pattern on the astronaut head.
+
+## Parameters
+- **uTime** – updated every frame to animate the pattern.
+- **uVolume** – real-time RMS volume from `useAudioAnalyser`.
+- **uPitch** – spectral centroid (approximate pitch) from `useAudioAnalyser`.
+
+Pattern frequency scales with `uPitch` while animation speed and intensity follow `uVolume`.
+
+## Usage
+```tsx
+import { MoireShaderMaterial } from '../components/MoireShaderMaterial';
+
+<mesh geometry={geometry}>
+  <MoireShaderMaterial />
+</mesh>
+```
+Toggle the effect via the settings panel. The material is only rendered when `enableMoire` is true in the store.

--- a/prototype/frontend/src/App.tsx
+++ b/prototype/frontend/src/App.tsx
@@ -109,10 +109,12 @@ function App() {
     scaleModel,
     resetModel,
     toggleBackground,
+    toggleMoire,
     updateMorphTargetInfluence,
     resetAllMorphTargets,
     applyPresetExpression,
-    switchHeadModel
+    switchHeadModel,
+    enableMoire
   } = useHeadService();
   // --- 結束 --- 
   
@@ -493,8 +495,10 @@ function App() {
           scaleModel={scaleModel}
           resetModel={resetModel}
           toggleBackground={toggleBackground}
+          toggleMoire={toggleMoire}
           applyPresetExpression={applyPresetExpression}
           showSpaceBackground={showSpaceBackground}
+          enableMoire={enableMoire}
           // Pass body animation props
           availableAnimations={availableAnimations} 
           currentAnimation={currentAnimation} 

--- a/prototype/frontend/src/components/HeadModel.tsx
+++ b/prototype/frontend/src/components/HeadModel.tsx
@@ -6,6 +6,7 @@ import logger, { LogCategory } from '../utils/LogManager'; // Import logger
 import { Mesh } from 'three'; // Import Mesh type
 import { useStore } from '../store'; // 導入 Zustand store
 import { useEmotionalSpeaking } from '../hooks/useEmotionalSpeaking'; // <-- 導入新的 Hook
+import { MoireShaderMaterial } from './MoireShaderMaterial';
 // --- 移除模型設定導入 ---
 // import { EXTERNAL_ANIMATION_PATHS } from '../config/modelConfig';
 // --- 移除結束 ---
@@ -113,6 +114,7 @@ export const HeadModel: React.FC<HeadModelProps> = ({
   // --- 結束 ---
 
   const [localMorphTargetDictionary, setLocalMorphTargetDictionary] = useState<Record<string, number>>({});
+  const [moireGeometry, setMoireGeometry] = useState<THREE.BufferGeometry | null>(null);
 
   const { calculateCurrentTrajectoryWeights } = useEmotionalSpeaking();
 
@@ -131,11 +133,21 @@ export const HeadModel: React.FC<HeadModelProps> = ({
   // -- 新增：讀取語音音量強度 --
   const audioAverageVolumeFromStore = useStore((state) => state.audioAverageVolume);
   const audioAverageVolumeRef = useRef(audioAverageVolumeFromStore);
+  const enableMoire = useStore((state) => state.enableMoire);
   // -- 新增結束 --
 
   useEffect(() => {
     manualOrPresetTargetsRef.current = manualOrPresetTargetsFromStore;
   }, [manualOrPresetTargetsFromStore]);
+
+  // Clean up moir\u00e9 geometry when model URL changes
+  useEffect(() => {
+    return () => {
+      if (moireGeometry) {
+        moireGeometry.dispose();
+      }
+    };
+  }, [headModelUrl]);
   // -- 新增：更新語音口型 Ref -- 
   useEffect(() => {
     audioLipsyncTargetsRef.current = audioLipsyncTargetsFromStore;
@@ -181,6 +193,7 @@ export const HeadModel: React.FC<HeadModelProps> = ({
           foundMeshWithMorphs = true;
           finalDict = meshWithMorphs.morphTargetDictionary || null;
           setLocalMorphTargetDictionary(finalDict || {});
+          setMoireGeometry(meshWithMorphs.geometry.clone());
           logger.info('HeadModel: Found mesh with morph targets.', LogCategory.MODEL, JSON.stringify(finalDict));
           meshWithMorphs.morphTargetInfluences.fill(0);
           logger.info('HeadModel: Initialized morphTargetInfluences to 0.', LogCategory.MODEL);
@@ -471,10 +484,12 @@ export const HeadModel: React.FC<HeadModelProps> = ({
     <group ref={group} position={position} rotation={rotation}>
       {/* 使用drei的Center組件包裹scene，讓模型以視覺中心點進行縮放 */}
       <Center scale={scale} position={[0, 0, 0]}>
-        <primitive 
-          object={scene} 
-          key={headModelUrl} 
-        />
+        <primitive object={scene} key={headModelUrl} />
+        {enableMoire && moireGeometry && (
+          <mesh geometry={moireGeometry}>
+            <MoireShaderMaterial />
+          </mesh>
+        )}
       </Center>
     </group>
   );

--- a/prototype/frontend/src/components/MoireShaderMaterial.tsx
+++ b/prototype/frontend/src/components/MoireShaderMaterial.tsx
@@ -1,0 +1,50 @@
+import { shaderMaterial } from '@react-three/drei';
+import { extend, ReactThreeFiber, useFrame } from '@react-three/fiber';
+import { useRef } from 'react';
+import { useAudioAnalyser } from '../hooks/useAudioAnalyser';
+import * as THREE from 'three';
+
+const MoireMaterialImpl = shaderMaterial(
+  { uTime: 0, uVolume: 0, uPitch: 0 },
+  `varying vec2 vUv;
+   void main() {
+     vUv = uv;
+     gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0);
+   }`,
+  `uniform float uTime;
+   uniform float uVolume;
+   uniform float uPitch;
+   varying vec2 vUv;
+   void main() {
+     float freq = mix(5.0, 30.0, clamp(uPitch / 3000.0, 0.0, 1.0));
+     float speed = 1.0 + uVolume * 3.0;
+     float intensity = 0.5 + uVolume * 0.5;
+     vec2 st = vUv * freq;
+     float pattern = sin(st.x + uTime * speed) * sin(st.y - uTime * speed);
+     float val = 0.5 + 0.5 * pattern;
+     gl_FragColor = vec4(vec3(val * intensity), intensity * 0.4);
+   }`
+);
+
+extend({ MoireMaterialImpl });
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      moireMaterialImpl: ReactThreeFiber.Object3DNode<any, typeof MoireMaterialImpl>;
+    }
+  }
+}
+
+export const MoireShaderMaterial: React.FC = ({ children }) => {
+  const ref = useRef<any>();
+  const { volume, pitch } = useAudioAnalyser();
+  useFrame(({ clock }) => {
+    if (ref.current) {
+      ref.current.uTime = clock.elapsedTime;
+      ref.current.uVolume = volume;
+      ref.current.uPitch = pitch;
+    }
+  });
+  return <moireMaterialImpl ref={ref} transparent>{children}</moireMaterialImpl>;
+};

--- a/prototype/frontend/src/components/SettingsPanel.tsx
+++ b/prototype/frontend/src/components/SettingsPanel.tsx
@@ -58,9 +58,11 @@ interface SettingsPanelProps {
   scaleModel: (factor: number) => void;
   resetModel: () => void;
   toggleBackground: () => void;
+  toggleMoire: () => void;
   selectAnimation: (animationName: string) => void;
   applyPresetExpression: (expression: string) => Promise<boolean>;
   showSpaceBackground: boolean;
+  enableMoire: boolean;
   // Emotion State Props (optional display)
   currentEmotion: string;
   emotionConfidence: number;
@@ -93,9 +95,11 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
   scaleModel,
   resetModel,
   toggleBackground,
+  toggleMoire,
   selectAnimation,
   applyPresetExpression,
   showSpaceBackground,
+  enableMoire,
   // Emotion State Props
   currentEmotion,
   emotionConfidence,
@@ -288,6 +292,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
               <button onClick={() => scaleModel(0.9)} disabled={!isModelLoaded} className={buttonClasses(false, !isModelLoaded)}>縮小</button>
               <button onClick={resetModel} disabled={!isModelLoaded} className={buttonClasses(false, !isModelLoaded)}>重置</button>
               <button onClick={toggleBackground} className={buttonClasses(showSpaceBackground)}> {showSpaceBackground ? '顯示背景' : '隱藏背景'} </button>
+              <button onClick={toggleMoire} className={buttonClasses(enableMoire)}> {enableMoire ? '關閉 Moiré' : '開啟 Moiré'} </button>
             </div>
             <div className="text-xs text-gray-500 dark:text-gray-400">
               縮放: {typeof currentModelScale === 'number' ? currentModelScale.toFixed(2) : 'N/A'} | 狀態: {isModelLoaded ? '已載入' : '載入中...'}

--- a/prototype/frontend/src/hooks/useAudioAnalyser.ts
+++ b/prototype/frontend/src/hooks/useAudioAnalyser.ts
@@ -1,0 +1,7 @@
+import { useStore } from '../store';
+
+export const useAudioAnalyser = () => {
+  const volume = useStore((s) => s.audioAverageVolume);
+  const pitch = useStore((s) => s.audioPitch);
+  return { volume, pitch };
+};

--- a/prototype/frontend/src/services/AudioService.ts
+++ b/prototype/frontend/src/services/AudioService.ts
@@ -421,6 +421,19 @@ class AudioService {
     }
     const rms = Math.sqrt(sumOfSquares / this.playbackDataArray.length);
 
+    // 計算頻譜重心 (用於音高估計)
+    const freqData = new Uint8Array(this.playbackAnalyserNode.frequencyBinCount);
+    this.playbackAnalyserNode.getByteFrequencyData(freqData);
+    let weightedSum = 0;
+    let magSum = 0;
+    const hzPerBin = (this.audioContext?.sampleRate || 44100) / this.playbackAnalyserNode.fftSize;
+    for (let i = 0; i < freqData.length; i++) {
+        const mag = freqData[i];
+        weightedSum += mag * i * hzPerBin;
+        magSum += mag;
+    }
+    const centroid = magSum ? weightedSum / magSum : 0;
+
     // 將 RMS 值映射到 jawOpen (需要調整映射函數和閾值)
     const sensitivity = 4.0; // 靈敏度調整
     const threshold = 0.01; // 音量閾值，低於此值視為靜音
@@ -433,6 +446,7 @@ class AudioService {
     // useStore.getState().updateMorphTarget('jawOpen', jawOpenValue);
     useStore.getState().setAudioLipsyncTarget('jawOpen', jawOpenValue); // <-- 使用新 Action
     useStore.getState().setAudioAverageVolume(rms); // <-- 新增：設定平均音量
+    useStore.getState().setAudioPitch(centroid); // <-- 新增：設定音高
     
     // 移除之前的調試日誌
     // logger.debug(`[AnalyseFrame] RMS: ${rms.toFixed(3)}, jawOpen: ${jawOpenValue.toFixed(3)}`, LogCategory.AUDIO);

--- a/prototype/frontend/src/services/HeadService.ts
+++ b/prototype/frontend/src/services/HeadService.ts
@@ -242,6 +242,12 @@ class HeadService {
     this.setShowSpaceBackground(!this.getShowSpaceBackground());
   }
 
+  // 切換莫爾條紋著色器
+  public toggleMoire(): void {
+    const current = useStore.getState().enableMoire;
+    useStore.getState().setEnableMoire(!current);
+  }
+
   // 應用預設表情 (保持不變，操作 Morph Targets)
   public async applyPresetExpression(expression: string): Promise<boolean> {
     logger.info(`應用表情預設 (前端): ${expression}`, LogCategory.MODEL);
@@ -343,6 +349,7 @@ export function useHeadService() { // <-- 保留這個定義
   const modelRotation = useStore((state) => state.modelRotation);
   const modelPosition = useStore((state) => state.modelPosition);
   const showSpaceBackground = useStore((state) => state.showSpaceBackground);
+  const enableMoire = useStore((state) => state.enableMoire);
   const morphTargets = useStore((state) => state.morphTargets);
   const morphTargetDictionary = useStore((state) => state.morphTargetDictionary);
 
@@ -372,6 +379,10 @@ export function useHeadService() { // <-- 保留這個定義
 
   const toggleBackground = useCallback(() => {
     headService.current.toggleBackground();
+  }, []);
+
+  const toggleMoire = useCallback(() => {
+    headService.current.toggleMoire();
   }, []);
 
   const updateMorphTargetInfluence = useCallback((name: string, value: number) => {
@@ -408,7 +419,9 @@ export function useHeadService() { // <-- 保留這個定義
     updateMorphTargetInfluence,
     resetAllMorphTargets,
     applyPresetExpression,
-    switchHeadModel
+    switchHeadModel,
+    toggleMoire,
+    enableMoire
   };
 }
 

--- a/prototype/frontend/src/store/slices/headSlice.ts
+++ b/prototype/frontend/src/store/slices/headSlice.ts
@@ -14,11 +14,13 @@ export interface HeadSlice {
   morphTargets: Record<string, number>; // 用戶手動/預設的目標
   audioLipsyncTargets: Record<string, number>; // <-- 新增：語音驅動的口型目標
   audioAverageVolume: number; // <-- 新增：音訊平均音量
+  audioPitch: number; // <-- 新增：音高(頻譜重心)
   morphTargetDictionary: Record<string, number> | null;
   // availableAnimations: string[]; // 移除動畫狀態
   // currentAnimation: string | null;
   headModelLoaded: boolean; // 重命名
   showSpaceBackground: boolean; // 保留場景狀態
+  enableMoire: boolean; // <-- 新增：是否啟用莫爾條紋著色器
   
   // 操作：模型基本資訊
   setHeadModelUrl: (url: string) => void; // 重命名
@@ -42,6 +44,7 @@ export interface HeadSlice {
   // 操作：語音口型 Morph Targets
   setAudioLipsyncTarget: (key: string, value: number) => void; // <-- 新增 Action
   setAudioAverageVolume: (volume: number) => void; // <-- 新增 Action
+  setAudioPitch: (pitch: number) => void; // <-- 新增 Action
   
   // 操作：動畫相關 (移除)
   // setAvailableAnimations: (animations: string[]) => void;
@@ -49,6 +52,7 @@ export interface HeadSlice {
   
   // 操作：場景相關
   setShowSpaceBackground: (show: boolean) => void;
+  setEnableMoire: (enable: boolean) => void;
 }
 
 // 創建 Head Slice (原 createModelSlice)
@@ -61,11 +65,13 @@ export const createHeadSlice: StateCreator<HeadSlice> = (set) => ({
   morphTargets: {},
   audioLipsyncTargets: {}, // <-- 初始化新狀態
   audioAverageVolume: 0, // <-- 初始化新狀態
+  audioPitch: 0, // <-- 初始化新狀態
   morphTargetDictionary: null,
   // availableAnimations: [], // 移除
   // currentAnimation: null, // 移除
   headModelLoaded: false, // 重命名
   showSpaceBackground: true,
+  enableMoire: false,
   
   // 操作實現
   setHeadModelUrl: (url) => set({ // 重命名 Action
@@ -123,6 +129,7 @@ export const createHeadSlice: StateCreator<HeadSlice> = (set) => ({
   
   // --- 新增音訊平均音量 Action 實現 ---
   setAudioAverageVolume: (volume) => set({ audioAverageVolume: volume }),
+  setAudioPitch: (pitch) => set({ audioPitch: pitch }),
   // --- 新增結束 ---
   
   // 移除動畫相關 Actions
@@ -130,4 +137,5 @@ export const createHeadSlice: StateCreator<HeadSlice> = (set) => ({
   // setCurrentAnimation: (animation) => set({ currentAnimation: animation }),
   
   setShowSpaceBackground: (show) => set({ showSpaceBackground: show }),
+  setEnableMoire: (enable) => set({ enableMoire: enable }),
 }); 


### PR DESCRIPTION
## Summary
- implement `MoireShaderMaterial` with custom shader
- compute spectral centroid in `AudioService`
- expose audio pitch and moire toggle in Zustand store and `HeadService`
- integrate effect on head model and settings panel
- document shader usage

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest`
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: connect EHOSTUNREACH)*