### PR TITLE
Add music-driven dancer radius

### DIFF
--- a/docs/frontend/dance_group_component.md
+++ b/docs/frontend/dance_group_component.md
@@ -111,3 +111,21 @@ import DanceGroup from '@/components/DanceGroup';
 
 `SceneContainer.tsx` 已改為使用 `DanceGroup` 取代單一 `BodyModel`，預設會顯示30個具有漂浮效果的舞者圓形佈局。
 
+### 音樂反應的動態半徑
+
+`dynamicRadius` 屬性允許圓形舞群依據背景音樂強度自動調整半徑，形成隨節奏擴張與收縮的視覺效果：
+
+```tsx
+<DanceGroup
+  count={100}
+  scale={8}
+  forceCircular
+  dynamicRadius
+  radiusFactor={0.8}
+  circleRadius={60}
+  enableFloating={false}
+/>
+```
+
+`radiusFactor` 控制音量對半徑的影響幅度，值越大，變化越明顯。
+

--- a/prototype/frontend/src/components/DanceGroup.tsx
+++ b/prototype/frontend/src/components/DanceGroup.tsx
@@ -1,6 +1,7 @@
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { Group } from 'three';
+import { Group, MathUtils } from 'three';
+import { useStore } from '../store';
 import BodyModel from './BodyModel';
 
 interface DanceGroupProps {
@@ -18,6 +19,10 @@ interface DanceGroupProps {
   forceCircular?: boolean;
   /** Radius for circular layout */
   circleRadius?: number;
+  /** Enable dynamic radius based on bgm intensity */
+  dynamicRadius?: boolean;
+  /** Scale factor for radius when dynamicRadius is true */
+  radiusFactor?: number;
 }
 
 // 生成圓形或網格佈局的位置
@@ -89,15 +94,27 @@ interface FloatingDancerProps {
   scale: number;
   index: number;
   enableFloating: boolean;
+  dynamicRadius?: boolean;
+  radiusFactor: number;
 }
 
-const FloatingDancer: React.FC<FloatingDancerProps> = ({ 
-  position, 
-  scale, 
-  index, 
-  enableFloating 
+const FloatingDancer: React.FC<FloatingDancerProps> = ({
+  position,
+  scale,
+  index,
+  enableFloating,
+  dynamicRadius,
+  radiusFactor
 }) => {
   const groupRef = useRef<Group>(null);
+
+  const baseRadiusRef = useRef(Math.sqrt(position[0] * position[0] + position[2] * position[2]));
+  const angleRef = useRef(Math.atan2(position[2], position[0]));
+
+  const bgmRef = useRef(useStore.getState().bgmIntensity);
+  useEffect(() => useStore.subscribe((s) => (bgmRef.current = s.bgmIntensity)), []);
+
+  const currentRadiusRef = useRef(baseRadiusRef.current);
   
   // 為每個舞者生成不同的漂浮參數
   const floatingParams = {
@@ -114,25 +131,36 @@ const FloatingDancer: React.FC<FloatingDancerProps> = ({
   };
 
   useFrame((state) => {
-    if (!groupRef.current || !enableFloating) return;
-    
+    if (!groupRef.current) return;
+
     const time = state.clock.getElapsedTime();
-    
-    // Y軸漂浮動畫
-    const yOffset = Math.sin(time * floatingParams.yFrequency + floatingParams.yPhase) * floatingParams.yAmplitude;
-    
-    // 輕微的旋轉動畫，模擬失重漂浮
-    const rotationY = Math.sin(time * floatingParams.rotationFrequency + floatingParams.rotationPhase) * floatingParams.rotationAmplitude;
-    const rotationX = Math.cos(time * floatingParams.rotationFrequency * 0.7 + floatingParams.rotationPhase) * floatingParams.rotationAmplitude * 0.5;
-    const rotationZ = Math.sin(time * floatingParams.rotationFrequency * 1.3 + floatingParams.rotationPhase) * floatingParams.rotationAmplitude * 0.3;
-    
-    // 應用位置和旋轉
-    groupRef.current.position.set(
-      position[0],
-      position[1] + yOffset,
-      position[2]
-    );
-    
+
+    let yOffset = 0;
+    let rotationX = 0;
+    let rotationY = 0;
+    let rotationZ = 0;
+
+    if (enableFloating) {
+      // Y軸漂浮動畫
+      yOffset = Math.sin(time * floatingParams.yFrequency + floatingParams.yPhase) * floatingParams.yAmplitude;
+
+      // 輕微旋轉模擬失重
+      rotationY = Math.sin(time * floatingParams.rotationFrequency + floatingParams.rotationPhase) * floatingParams.rotationAmplitude;
+      rotationX = Math.cos(time * floatingParams.rotationFrequency * 0.7 + floatingParams.rotationPhase) * floatingParams.rotationAmplitude * 0.5;
+      rotationZ = Math.sin(time * floatingParams.rotationFrequency * 1.3 + floatingParams.rotationPhase) * floatingParams.rotationAmplitude * 0.3;
+    }
+
+    // 動態半徑計算
+    let x = position[0];
+    let z = position[2];
+    if (dynamicRadius) {
+      const target = baseRadiusRef.current * (1 + bgmRef.current * radiusFactor);
+      currentRadiusRef.current = MathUtils.lerp(currentRadiusRef.current, target, 0.1);
+      x = Math.cos(angleRef.current) * currentRadiusRef.current;
+      z = Math.sin(angleRef.current) * currentRadiusRef.current;
+    }
+
+    groupRef.current.position.set(x, position[1] + yOffset, z);
     groupRef.current.rotation.set(rotationX, rotationY, rotationZ);
   });
 
@@ -143,13 +171,15 @@ const FloatingDancer: React.FC<FloatingDancerProps> = ({
   );
 };
 
-const DanceGroup: React.FC<DanceGroupProps> = ({ 
-  positions, 
-  scale = 5, 
+const DanceGroup: React.FC<DanceGroupProps> = ({
+  positions,
+  scale = 5,
   count = 30,
   enableFloating = true,
   forceCircular,
-  circleRadius
+  circleRadius,
+  dynamicRadius = false,
+  radiusFactor = 0.5
 }) => {
   const finalPositions = positions || generatePositions(count, forceCircular, circleRadius);
   
@@ -162,6 +192,8 @@ const DanceGroup: React.FC<DanceGroupProps> = ({
           scale={scale}
           index={idx}
           enableFloating={enableFloating}
+          dynamicRadius={dynamicRadius}
+          radiusFactor={radiusFactor}
         />
       ))}
     </>

--- a/prototype/frontend/src/components/SceneContainer.tsx
+++ b/prototype/frontend/src/components/SceneContainer.tsx
@@ -89,12 +89,14 @@ const SceneContainer: React.FC<SceneContainerProps> = ({
           const armyPosition: [number, number, number] = [0, -25, 0]; // 再往下移動更多
           return (
             <group position={armyPosition}>
-              <DanceGroup 
-                count={100} 
-                scale={8} 
-                enableFloating={false} 
+              <DanceGroup
+                count={100}
+                scale={8}
+                enableFloating={false}
                 forceCircular={true}
                 circleRadius={60}
+                dynamicRadius
+                radiusFactor={0.8}
               />
             </group>
           );


### PR DESCRIPTION
## Summary
- adjust DanceGroup component to optionally scale circle radius with BGM intensity
- allow SceneContainer to use dynamic radius for the 100 dancer formation
- document `dynamicRadius` usage in dance_group_component doc

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest` *(no tests ran)*
- `npx markdownlint "**/*.md" --ignore node_modules` *(failed: npx unavailable)*