### PR TITLE
Fix audio CORS issue causing lipsync failure

### DIFF
--- a/prototype/frontend/src/services/AudioService.ts
+++ b/prototype/frontend/src/services/AudioService.ts
@@ -254,8 +254,10 @@ class AudioService {
         audioUrl = audioData;
       }
 
-      this.playbackAudio = new Audio(audioUrl);
-      this.playbackAudio.crossOrigin = "anonymous"; // 允許跨域加載，如果需要的話
+      // 為避免跨域限制造成分析失敗，需在設置 src 之前指定 crossOrigin
+      this.playbackAudio = new Audio();
+      this.playbackAudio.crossOrigin = "anonymous"; // 允許跨域加載
+      this.playbackAudio.src = audioUrl;
       this.playbackAudio.volume = useStore.getState().ttsVolume;
 
       // --- 獲取精確時長 --- 


### PR DESCRIPTION
## Summary
- ensure crossOrigin attribute set before assigning audio src to avoid intermittent analyser failures

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest` *(passes: no tests run)*
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: network required)*