### PR TITLE
Add video player component

### DIFF
--- a/prototype/frontend/src/components/SpeechBackground.tsx
+++ b/prototype/frontend/src/components/SpeechBackground.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import { Text } from '@react-three/drei';
+import VideoPlayer from './VideoPlayer';
 import { useStore } from '../store';
 import * as THREE from 'three';
 import logger, { LogCategory } from '../utils/LogManager';
@@ -198,6 +199,8 @@ const SpeechBackground: React.FC = () => {
   // 定義背景「大螢幕」區域
   const screenWidth = viewport.width * 0.8;
   const screenHeight = viewport.height * 0.6;
+  const videoWidth = viewport.width * 0.4;
+  const videoX = screenWidth / 2 + videoWidth / 2 + viewport.width * 0.1;
 
   return (
     <group position={[0, 50, -70]}>
@@ -245,6 +248,12 @@ const SpeechBackground: React.FC = () => {
           )}
         </Text>
       )}
+
+      {/* Video player positioned next to the big screen */}
+      <VideoPlayer
+        playlist={["/videos/space_live.mp4"]}
+        position={[videoX, 0, 0]}
+      />
     </group>
   );
 };

--- a/prototype/frontend/src/components/VideoPlayer.tsx
+++ b/prototype/frontend/src/components/VideoPlayer.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useThree, useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import * as THREE from 'three';
+
+interface VideoPlayerProps {
+  playlist: string[];
+  position?: [number, number, number];
+  rotation?: [number, number, number];
+  scale?: [number, number, number];
+}
+
+const VideoPlayer: React.FC<VideoPlayerProps> = ({
+  playlist,
+  position = [0, 0, 0],
+  rotation = [0, 0, 0],
+  scale = [1, 1, 1]
+}) => {
+  const { viewport } = useThree();
+  const [index, setIndex] = useState(0);
+  const videoRef = useRef<HTMLVideoElement>();
+  const textureRef = useRef<THREE.VideoTexture>();
+  const materialRef = useRef<THREE.MeshBasicMaterial>(null);
+
+  useEffect(() => {
+    const video = document.createElement('video');
+    video.crossOrigin = 'anonymous';
+    video.loop = false;
+    video.playsInline = true;
+    videoRef.current = video;
+
+    return () => {
+      video.pause();
+      textureRef.current?.dispose();
+    };
+  }, []);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const src = playlist[index];
+    video.src = src;
+    video.load();
+    const handleEnded = () => {
+      setTimeout(() => {
+        setIndex((i) => (i + 1) % playlist.length);
+      }, 5000);
+    };
+    video.addEventListener('ended', handleEnded);
+    video.play();
+
+    textureRef.current = new THREE.VideoTexture(video);
+    textureRef.current.needsUpdate = true;
+    textureRef.current.minFilter = THREE.LinearFilter;
+    textureRef.current.magFilter = THREE.LinearFilter;
+    textureRef.current.format = THREE.RGBFormat;
+
+    if (materialRef.current) {
+      materialRef.current.map = textureRef.current;
+      materialRef.current.needsUpdate = true;
+    }
+
+    return () => {
+      video.pause();
+      video.removeEventListener('ended', handleEnded);
+      textureRef.current?.dispose();
+      textureRef.current = undefined;
+    };
+  }, [index, playlist]);
+
+  useFrame(() => {
+    if (textureRef.current) textureRef.current.needsUpdate = true;
+  });
+
+  const play = () => videoRef.current?.play();
+  const pause = () => videoRef.current?.pause();
+  const restart = () => {
+    if (videoRef.current) {
+      videoRef.current.currentTime = 0;
+      videoRef.current.play();
+    }
+  };
+  const setVolume = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (videoRef.current) {
+      videoRef.current.volume = parseFloat(e.target.value);
+    }
+  };
+
+  const width = viewport.width * 0.4;
+  const height = viewport.height * 0.25;
+
+  return (
+    <group position={position} rotation={rotation} scale={scale}>
+      <mesh>
+        <planeGeometry args={[width, height]} />
+        <meshBasicMaterial ref={materialRef} toneMapped={false} />
+      </mesh>
+      <Html position={[0, -height * 0.7, 0]} center>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <button onClick={play}>Play</button>
+          <button onClick={pause}>Pause</button>
+          <button onClick={restart}>Restart</button>
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.01"
+            defaultValue="1"
+            onChange={setVolume}
+          />
+        </div>
+      </Html>
+    </group>
+  );
+};
+
+export default VideoPlayer;

--- a/prototype/frontend/src/components/__tests__/VideoPlayer.test.tsx
+++ b/prototype/frontend/src/components/__tests__/VideoPlayer.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { Canvas } from '@react-three/fiber';
+import VideoPlayer from '../VideoPlayer';
+
+test('render video player without crashing', () => {
+  render(
+    <Canvas>
+      <VideoPlayer playlist={["/videos/space_live.mp4"]} />
+    </Canvas>
+  );
+});


### PR DESCRIPTION
## Summary
- add `VideoPlayer` R3F component with playlist and controls
- embed the video player next to the big screen in `SpeechBackground`
- add basic render test for the player

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm run format` *(fails: Invalid configuration, missing dependencies)*