### PR TITLE
Add 3D video player

### DIFF
--- a/docs/display_backgrounds_overview.md
+++ b/docs/display_backgrounds_overview.md
@@ -11,6 +11,7 @@
 | 07 | EffectBackground | ./prototype/frontend/src/components/EffectBackground.tsx | R3F/Three.js | `useFrame` | `effectTrigger` |
 | 08 | DynamicAudioBackgrounds | ./prototype/frontend/src/components/DynamicAudioBackgrounds.tsx | R3F/Three.js | None | composite |
 | 09 | P5SpaceEffect | ./prototype/frontend/src/components/P5SpaceEffect.tsx | R3F/Three.js | `useFrame` | `bgmIntensity` |
+| 10 | VideoPlayer | ./prototype/frontend/src/components/VideoPlayer.tsx | R3F/Three.js | `video events` | `playlist` |
 
 ```mermaid
 sequenceDiagram
@@ -66,3 +67,4 @@ sequenceDiagram
 - `EffectBackground` 的粒子效果已增強，具有更長的持續時間和更誇張的效果。
 - `P5SpaceEffect` 提供 p5.js 風格的粒子系統，創建太空中漂浮的粒子效果。
 - 所有音頻驅動的背景系統現在通過 `DynamicAudioBackgrounds` 組件整合在一起，使管理更加集中和模塊化。
+- `VideoPlayer` 於大螢幕旁顯示影片，播放清單中的檔案並自動輪播，若瀏覽器阻擋自動播放需手動點擊啟動。

--- a/docs/frontend/video_player_component.md
+++ b/docs/frontend/video_player_component.md
@@ -1,0 +1,24 @@
+# VideoPlayer 元件
+
+`VideoPlayer` 在 3D 場景中顯示一塊 2:3 的影片螢幕，並自動循環播放 `public/videos` 目錄下的影片。
+
+## 功能特點
+
+- 使用 `THREE.VideoTexture` 將 HTML `<video>` 的畫面貼在平面上。
+- 影片清單預設包含 `space_live.mp4` 與 `Drive_in_stormy.mp4`，播放完畢後等待 5 秒自動切換下一支。
+- 若瀏覽器限制自動播放，畫面會顯示提示，使用者點擊一次即可開始播放。
+- 提供播放、暫停、重新開始與音量控制等基本操作。
+- 影片平面預設位置在大螢幕旁邊，可透過 `position` 與 `width` 屬性調整。
+
+## 使用方式
+
+```tsx
+import VideoPlayer from '@/components/VideoPlayer';
+
+// 在場景中放置影片螢幕
+<VideoPlayer />
+```
+
+## 效能建議
+
+影片解析度建議控制在 720p 或以下，以減少對 GPU 的負擔。`VideoTexture` 會關閉 Mipmaps 並使用線性過濾，確保在大多數裝置上維持流暢播放。

--- a/prototype/frontend/src/components/DynamicAudioBackgrounds.tsx
+++ b/prototype/frontend/src/components/DynamicAudioBackgrounds.tsx
@@ -3,10 +3,13 @@ import SpeechBackground from './SpeechBackground';
 import MusicBackground from './MusicBackground';
 import EffectBackground from './EffectBackground';
 import P5SpaceEffect from './P5SpaceEffect';
+import VideoPlayer from './VideoPlayer';
 
 const DynamicAudioBackgrounds: React.FC = () => (
   <>
     <SpeechBackground />
+    {/* Video player positioned next to the big screen */}
+    <VideoPlayer />
     <MusicBackground />
     <EffectBackground />
     <P5SpaceEffect />

--- a/prototype/frontend/src/components/VideoPlayer.tsx
+++ b/prototype/frontend/src/components/VideoPlayer.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useRef, useState, useMemo } from 'react';
+import { useThree } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import * as THREE from 'three';
+
+/**
+ * VideoPlayer renders a plane with a video texture inside the 3D scene.
+ * - Videos are loaded from the public/videos directory.
+ * - Maintains a 2:3 aspect ratio by default.
+ * - Automatically cycles through the playlist with a 5s delay between items.
+ * - If autoplay is blocked, user must click the screen once to start playback.
+ * - Basic controls (play, pause, restart, volume) are exposed via on-screen HTML controls.
+ *
+ * This component is designed to be lightweight. For performance, keep video
+ * resolutions modest (720p or lower). Videos are preloaded and reused via a
+ * single HTMLVideoElement and THREE.VideoTexture.
+ */
+interface VideoPlayerProps {
+  /** playlist of video file names relative to /public/videos */
+  playlist?: string[];
+  /** position of the video plane in the scene */
+  position?: [number, number, number];
+  /** width of the plane; height is derived from 2:3 aspect ratio */
+  width?: number;
+}
+
+const DEFAULT_PLAYLIST = [
+  '/videos/space_live.mp4',
+  '/videos/Drive_in_stormy.mp4'
+];
+
+const VideoPlayer: React.FC<VideoPlayerProps> = ({
+  playlist = DEFAULT_PLAYLIST,
+  position = [35, 50, -70],
+  width = 20
+}) => {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const textureRef = useRef<THREE.VideoTexture>();
+  const [index, setIndex] = useState(0);
+  const [autoplayFailed, setAutoplayFailed] = useState(false);
+  const { gl } = useThree();
+
+  const height = useMemo(() => (width * 3) / 2, [width]);
+
+  // load current video
+  useEffect(() => {
+    const video = videoRef.current ?? document.createElement('video');
+    videoRef.current = video;
+    video.src = playlist[index];
+    video.crossOrigin = 'anonymous';
+    video.loop = false;
+    video.preload = 'auto';
+    video.playsInline = true;
+    video.load();
+
+    const texture = textureRef.current ?? new THREE.VideoTexture(video);
+    textureRef.current = texture;
+    texture.needsUpdate = true;
+    texture.minFilter = THREE.LinearFilter;
+    texture.magFilter = THREE.LinearFilter;
+    texture.generateMipmaps = false;
+
+    const attempt = video
+      .play()
+      .catch(() => {
+        setAutoplayFailed(true);
+      });
+
+    return () => {
+      video.pause();
+    };
+  }, [index, playlist]);
+
+  // handle video end -> next video after delay
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    const handleEnded = () => {
+      setTimeout(() => {
+        setIndex((i) => (i + 1) % playlist.length);
+      }, 5000);
+    };
+    video.addEventListener('ended', handleEnded);
+    return () => video.removeEventListener('ended', handleEnded);
+  }, [playlist.length]);
+
+  const handlePlay = () => {
+    videoRef.current?.play();
+    setAutoplayFailed(false);
+  };
+  const handlePause = () => videoRef.current?.pause();
+  const handleRestart = () => {
+    if (videoRef.current) {
+      videoRef.current.currentTime = 0;
+      videoRef.current.play();
+    }
+  };
+  const handleVolume = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (videoRef.current) {
+      videoRef.current.volume = parseFloat(e.target.value);
+    }
+  };
+
+  return (
+    <group position={position}>
+      <mesh onClick={handlePlay}>
+        <planeGeometry args={[width, height]} />
+        <meshBasicMaterial toneMapped={false}>
+          {textureRef.current && <primitive attach="map" object={textureRef.current} />}
+        </meshBasicMaterial>
+      </mesh>
+      {/* HTML controls overlay */}
+      <Html position={[0, -height / 2 - 2, 0]} center>
+        <div style={{ display: 'flex', gap: '0.5rem', background: '#0008', padding: '0.5rem', borderRadius: '4px' }}>
+          <button onClick={handlePlay}>Play</button>
+          <button onClick={handlePause}>Pause</button>
+          <button onClick={handleRestart}>Restart</button>
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.01"
+            defaultValue="1"
+            onChange={handleVolume}
+          />
+        </div>
+        {autoplayFailed && <div>Click video to start</div>}
+      </Html>
+    </group>
+  );
+};
+
+export default VideoPlayer;

--- a/prototype/frontend/src/components/__tests__/VideoPlayer.test.tsx
+++ b/prototype/frontend/src/components/__tests__/VideoPlayer.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { Canvas } from '@react-three/fiber';
+import VideoPlayer from '../VideoPlayer';
+
+test('renders VideoPlayer in Canvas', () => {
+  render(
+    <Canvas>
+      <VideoPlayer />
+    </Canvas>
+  );
+});


### PR DESCRIPTION
## Summary
- add `VideoPlayer` component to render a 2:3 video plane
- integrate player into `DynamicAudioBackgrounds`
- document how to use the new component
- list the player in background overview
- add basic test for the component

## Testing
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: command not found)*
- `npm test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `pytest`