### PR TITLE
Add TechLight rig feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ Space Live Project 是一個互動藝術裝置，模擬一名被困於太空艙�
   - **EffectBackground**：對特定事件觸發的粒子效果
   - **P5SpaceEffect**：P5.js風格的粒子系統
 
+## TechLight Rig
+
+新增的 `HeadRigTechLight` 元件在頭部周圍生成可展開的雷射發射器環。透過
+Zustand 的 `showState` 控制四種表演狀態，並可調整發射器數量與半徑。
+
+開發環境啟動後可按鍵盤 `1-4` 觀察不同效果。所有幾何與材質在 `useMemo`
+中建立，卸載時自動 dispose，Bloom 後處理僅在 drop 狀態啟用，以降低性能
+開銷。
+
 ## 快速開始
 
 ### 前端開發

--- a/prototype/frontend/src/components/HeadRigTechLight.tsx
+++ b/prototype/frontend/src/components/HeadRigTechLight.tsx
@@ -1,0 +1,109 @@
+import React, { useRef, useEffect, useMemo } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { a, useSpring } from '@react-spring/three';
+import * as THREE from 'three';
+import { useStore } from '../store';
+import { ShowState } from '../store/slices/showSlice';
+import { createLaserMaterial } from '../utils/laserShader';
+import { createArmGeometry } from '../utils/armGeometry';
+import { EffectComposer, Bloom } from '@react-three/postprocessing';
+
+export const lasersEnabledForState = (state: ShowState) => state === 'drop';
+
+interface HeadRigTechLightProps {
+  parentRef: React.RefObject<THREE.Group>;
+}
+
+const HeadRigTechLight: React.FC<HeadRigTechLightProps> = ({ parentRef }) => {
+  const groupRef = useRef<THREE.Group>(null);
+  const showState = useStore((s) => s.showState);
+  const emitterCount = useStore((s) => s.emitterCount);
+  const ringRadius = useStore((s) => s.ringRadius);
+
+  useEffect(() => {
+    const parent = parentRef.current;
+    const child = groupRef.current;
+    if (parent && child) {
+      parent.add(child);
+      return () => {
+        parent.remove(child);
+      };
+    }
+  }, [parentRef]);
+
+  const armGeom = useMemo(() => createArmGeometry(), []);
+  const laserGeom = useMemo(() => new THREE.CylinderGeometry(0.005, 0.005, 2), []);
+  const armMat = useMemo(() => new THREE.MeshStandardMaterial({ color: 0x2266ff }), []);
+  const laserMat = useMemo(() => createLaserMaterial(0x44ffff), []);
+
+  useEffect(() => () => {
+    armGeom.dispose();
+    laserGeom.dispose();
+    armMat.dispose();
+    laserMat.dispose();
+  }, [armGeom, laserGeom, armMat, laserMat]);
+
+  const { armAngle, color, opacity } = useSpring({
+    armAngle:
+      showState === 'idle'
+        ? 0
+        : showState === 'buildUp'
+        ? Math.PI / 6
+        : showState === 'drop'
+        ? Math.PI / 2
+        : Math.PI / 4,
+    color: showState === 'coolDown' ? '#00ffff' : '#2266ff',
+    opacity: showState === 'coolDown' ? 0 : 1,
+  });
+
+  const rotationSpeed =
+    showState === 'buildUp'
+      ? (15 * Math.PI) / 180
+      : showState === 'drop'
+      ? (30 * Math.PI) / 180
+      : 0;
+
+  useFrame((state, delta) => {
+    if (groupRef.current) groupRef.current.rotation.y += rotationSpeed * delta;
+    if (lasersEnabledForState(showState)) {
+      const t = state.clock.elapsedTime;
+      laserMat.uniforms.intensity.value = 0.5 + 0.5 * (Math.sin(t * 8 * Math.PI) > 0 ? 1 : 0);
+    }
+  });
+
+  const angleStep = (2 * Math.PI) / emitterCount;
+
+  return (
+    <>
+      <group ref={groupRef} position={[0, 0.5, 0]}>
+        {Array.from({ length: emitterCount }).map((_, i) => (
+          <group key={i} rotation={[0, i * angleStep, 0]}>
+            <a.mesh
+              geometry={armGeom}
+              material={armMat}
+              rotation-z={armAngle}
+              position={[0, 0, ringRadius]}
+              material-color={color}
+              material-opacity={opacity}
+            />
+            {lasersEnabledForState(showState) && (
+              <mesh
+                geometry={laserGeom}
+                material={laserMat}
+                position={[0, 1.1, ringRadius + 0.1]}
+                rotation={[Math.PI / 2, 0, 0]}
+              />
+            )}
+          </group>
+        ))}
+      </group>
+      {lasersEnabledForState(showState) && (
+        <EffectComposer>
+          <Bloom intensity={1.2} />
+        </EffectComposer>
+      )}
+    </>
+  );
+};
+
+export default HeadRigTechLight;

--- a/prototype/frontend/src/components/SceneContainer.tsx
+++ b/prototype/frontend/src/components/SceneContainer.tsx
@@ -4,7 +4,9 @@ import { OrbitControls, Stars } from '@react-three/drei';
 import { HeadModel } from './HeadModel';
 import DanceGroup from './DanceGroup';
 import DynamicAudioBackgrounds from './DynamicAudioBackgrounds';
+import HeadRigTechLight from './HeadRigTechLight';
 import { useStore } from '../store';
+import { ShowState } from '../store/slices/showSlice';
 import * as THREE from 'three';
 import { useCameraManager, CameraPreset } from '../camera';
 
@@ -110,6 +112,23 @@ const SceneContent: React.FC<SceneContainerProps> = ({
 
   const cameraManager = useCameraManager(camera as THREE.PerspectiveCamera, cameraPresets, 'overview');
   const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const headGroupRef = useRef<THREE.Group>(null);
+  const setShowState = useStore((s) => s.setShowState);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      const map: Record<string, ShowState> = {
+        '1': 'idle',
+        '2': 'buildUp',
+        '3': 'drop',
+        '4': 'coolDown',
+      };
+      const state = map[e.key];
+      if (state) setShowState(state);
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [setShowState]);
 
   useEffect(() => {
     const switchView = () => {
@@ -145,13 +164,11 @@ const SceneContent: React.FC<SceneContainerProps> = ({
           // 調整頭部位置：移到圓圈中央
           const baseScale = 10;
           const basePosition: [number, number, number] = [0, -5, 0]; // 中央位置
-          
+
           return (
-            <group position={basePosition} scale={baseScale}>
-              <HeadModel 
-                headModelUrl={headModelUrl}
-                scale={modelScale}
-              />
+            <group ref={headGroupRef} position={basePosition} scale={baseScale}>
+              <HeadModel headModelUrl={headModelUrl} scale={modelScale} />
+              <HeadRigTechLight parentRef={headGroupRef} />
             </group>
           );
         })()}

--- a/prototype/frontend/src/components/__tests__/HeadRigTechLight.test.tsx
+++ b/prototype/frontend/src/components/__tests__/HeadRigTechLight.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import { Canvas } from '@react-three/fiber';
+import * as THREE from 'three';
+import HeadRigTechLight, { lasersEnabledForState } from '../HeadRigTechLight';
+
+// Basic render test
+test('renders tech light rig', () => {
+  const parent = new THREE.Group();
+  render(
+    <Canvas>
+      <HeadRigTechLight parentRef={{ current: parent }} />
+    </Canvas>
+  );
+});
+
+test('lasers enabled on drop state', () => {
+  expect(lasersEnabledForState('drop')).toBe(true);
+});

--- a/prototype/frontend/src/store/index.ts
+++ b/prototype/frontend/src/store/index.ts
@@ -10,6 +10,7 @@ import { BodySlice, createBodySlice } from './slices/bodySlice';
 import { AudioSettingsSlice, createAudioSettingsSlice } from './slices/audioSettingsSlice';
 import { BackgroundAudioSlice, createBackgroundAudioSlice } from './slices/backgroundAudioSlice';
 import { SpeechTextSlice, createSpeechTextSlice } from './slices/speechTextSlice';
+import { ShowSlice, createShowSlice } from './slices/showSlice';
 // import { EmotionSlice, createEmotionSlice } from './slices/emotionSlice';
 // import { AudioSlice, createAudioSlice } from './slices/audioSlice';
 
@@ -23,7 +24,8 @@ export type Store =
   BodySlice &
   AudioSettingsSlice &
   BackgroundAudioSlice &
-  SpeechTextSlice;
+  SpeechTextSlice &
+  ShowSlice;
 
 // 創建 Zustand Store
 export const useStore = create<Store>()(
@@ -38,6 +40,7 @@ export const useStore = create<Store>()(
       ...createAudioSettingsSlice(set, get, api),
       ...createBackgroundAudioSlice(set, get, api),
       ...createSpeechTextSlice(set, get, api),
+      ...createShowSlice(set, get, api),
     }),
     { name: 'AppStore' } // Optional: Name for Redux DevTools
   )

--- a/prototype/frontend/src/store/slices/showSlice.ts
+++ b/prototype/frontend/src/store/slices/showSlice.ts
@@ -1,0 +1,21 @@
+import { StateCreator } from 'zustand';
+
+export type ShowState = 'idle' | 'buildUp' | 'drop' | 'coolDown';
+
+export interface ShowSlice {
+  showState: ShowState;
+  emitterCount: number;
+  ringRadius: number;
+  setShowState: (s: ShowState) => void;
+  setEmitterCount: (n: number) => void;
+  setRingRadius: (r: number) => void;
+}
+
+export const createShowSlice: StateCreator<ShowSlice> = (set) => ({
+  showState: 'idle',
+  emitterCount: 12,
+  ringRadius: 1.2,
+  setShowState: (s) => set({ showState: s }),
+  setEmitterCount: (n) => set({ emitterCount: n }),
+  setRingRadius: (r) => set({ ringRadius: r }),
+});

--- a/prototype/frontend/src/utils/armGeometry.ts
+++ b/prototype/frontend/src/utils/armGeometry.ts
@@ -1,0 +1,3 @@
+import * as THREE from 'three';
+
+export const createArmGeometry = () => new THREE.CylinderGeometry(0.02, 0.02, 1);

--- a/prototype/frontend/src/utils/laserShader.ts
+++ b/prototype/frontend/src/utils/laserShader.ts
@@ -1,0 +1,29 @@
+import * as THREE from 'three';
+import { ShaderMaterial } from 'three';
+
+export const createLaserMaterial = (color: THREE.ColorRepresentation) => new ShaderMaterial({
+  uniforms: {
+    color: { value: new THREE.Color(color) },
+    intensity: { value: 1 },
+  },
+  vertexShader: `
+    varying vec2 vUv;
+    void main() {
+      vUv = uv;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `,
+  fragmentShader: `
+    uniform vec3 color;
+    uniform float intensity;
+    varying vec2 vUv;
+    void main() {
+      float dist = length(vUv - 0.5);
+      float alpha = smoothstep(0.5, 0.45, dist) * intensity;
+      gl_FragColor = vec4(color, alpha);
+    }
+  `,
+  transparent: true,
+  blending: THREE.AdditiveBlending,
+  depthWrite: false,
+});


### PR DESCRIPTION
## Summary
- integrate TechLight light crown above the head model
- store show state in new Zustand slice
- attach rig in SceneContainer and expose keyboard controls
- provide minimal shader utilities and tests
- document TechLight Rig usage

## Testing
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: connect EHOSTUNREACH)*
- `npm test --silent` in `prototype/frontend` *(fails: react-scripts not found)*
- `pytest` in `prototype/backend`