### PR TITLE
Add video wall control panel

### DIFF
--- a/docs/director-panel.md
+++ b/docs/director-panel.md
@@ -10,6 +10,8 @@ Press **D** to toggle the director panel drawer. The panel displays runtime info
 ## Video
 - Choose one of the sample videos from the list.
 - Toggle visibility with the checkbox.
+- Monitor and control the three-screen video wall via **VideoWallControlPanel**.
+  Each screen shows its current clip and allows selecting a new one in real time.
 
 ## Lighting
 - Switch between `idle`, `dramatic` and `calm` presets.

--- a/docs/frontend/video_wall_control_panel.md
+++ b/docs/frontend/video_wall_control_panel.md
@@ -1,0 +1,19 @@
+# VideoWallControlPanel
+
+The **VideoWallControlPanel** component exposes real-time controls for a three-screen video wall. It is rendered only when `VITE_DIRECTOR` is set to `true`.
+
+## Features
+
+- Displays the current video and visibility state for each screen.
+- Allows selecting a new clip from the predefined list in `resources.ts`.
+- Visibility of each screen can be toggled independently.
+- State is kept in the `videoScreens` slice of the Zustand store, so updates are reflected immediately in the 3D scene.
+
+## Usage
+
+```tsx
+import VideoWallControlPanel from '@/components/VideoWallControlPanel';
+
+// ... inside App
+<VideoWallControlPanel />
+```

--- a/prototype/frontend/src/App.tsx
+++ b/prototype/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import FloatingChatWindow from './components/FloatingChatWindow'
 import SettingsPanel from './components/SettingsPanel'
 import BackgroundSoundSystem from './components/BackgroundSoundSystem'
 import DirectorMonitorHUD from './components/DirectorMonitorHUD'
+import VideoWallControlPanel from './components/VideoWallControlPanel'
 import { usePerformanceMetrics } from './hooks/usePerformanceMetrics'
 
 // 引入服務
@@ -524,6 +525,7 @@ function App() {
         
         <ToastContainer />
         <DirectorMonitorHUD />
+        <VideoWallControlPanel />
       </div>
     </ErrorBoundary>
   )

--- a/prototype/frontend/src/components/DynamicAudioBackgrounds.tsx
+++ b/prototype/frontend/src/components/DynamicAudioBackgrounds.tsx
@@ -52,8 +52,9 @@ const DynamicAudioBackgrounds: React.FC = () => (
     <SpeechBackground />
     {/* Render multiple video players based on configs */}
     {screenConfigs.map(config => (
-      <VideoPlayer 
+      <VideoPlayer
         key={config.id}
+        screenId={config.id}
         playlist={config.playlist}
         initialVideoIndex={config.initialVideoIndex}
         position={config.position}

--- a/prototype/frontend/src/components/VideoPlayer.tsx
+++ b/prototype/frontend/src/components/VideoPlayer.tsx
@@ -18,6 +18,7 @@ import { useStore } from '../store';
  * single HTMLVideoElement and THREE.VideoTexture.
  */
 interface VideoPlayerProps {
+  screenId: string;
   playlist: string[];
   initialVideoIndex?: number;
   position?: [number, number, number];
@@ -29,6 +30,7 @@ interface VideoPlayerProps {
 }
 
 const VideoPlayer: React.FC<VideoPlayerProps> = ({
+  screenId,
   playlist,
   initialVideoIndex = 0,
   position = [25, 10, -20],
@@ -46,9 +48,10 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
 
   // 從 store 獲取音量強度
   const bgmIntensity = useStore((state) => state.bgmIntensity);
-  const setRuntime = useStore((s) => s.setRuntime);
-  const runtimeVideoId = useStore((s) => s.videoId);
-  const runtimeVisible = useStore((s) => s.videoVisible);
+  const screenState = useStore((s) =>
+    s.videoScreens.find((v) => v.id === screenId)
+  );
+  const setVideoScreen = useStore((s) => s.setVideoScreen);
 
   const height = useMemo(() => (width * 3) / 2, [width]);
 
@@ -102,14 +105,14 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
 
   // Follow runtime state
   useEffect(() => {
-    if (!runtimeVisible && videoRef.current) {
+    if (!screenState?.visible && videoRef.current) {
       videoRef.current.pause();
     }
-    if (runtimeVideoId) {
-      const idx = playlist.indexOf(runtimeVideoId);
+    if (screenState?.currentVideo) {
+      const idx = playlist.indexOf(screenState.currentVideo);
       if (idx >= 0) setIndex(idx);
     }
-  }, [runtimeVisible, runtimeVideoId]);
+  }, [screenState?.visible, screenState?.currentVideo]);
 
   useEffect(() => {
     if (!playlist || playlist.length === 0) {
@@ -145,7 +148,10 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       video.playbackRate = initialPlaybackRate;
       console.log('VideoPlayer: Set playback rate to', initialPlaybackRate);
 
-      setRuntime({ videoId: playlist[index], videoVisible: true });
+      setVideoScreen(screenId, {
+        currentVideo: playlist[index],
+        visible: true,
+      });
       
       video.play().then(() => {
         console.log('VideoPlayer: Video started playing');
@@ -182,7 +188,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       if (localTextureInstance) {
         localTextureInstance.dispose();
       }
-      setRuntime({ videoVisible: false, videoId: null });
+      setVideoScreen(screenId, { visible: false, currentVideo: '' });
     };
   }, [index, playlist]);
 
@@ -220,7 +226,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   const currentPlaybackRate = calculatePlaybackRate(bgmIntensity);
 
   return (
-    <group position={position} visible={runtimeVisible}>
+    <group position={position} visible={screenState?.visible}>
       <mesh 
         onClick={handlePlay}
         onPointerEnter={handleMouseEnter}

--- a/prototype/frontend/src/components/VideoWallControlPanel.tsx
+++ b/prototype/frontend/src/components/VideoWallControlPanel.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useStore } from '../store';
+import { DIRECTOR_VIDEOS } from '../config/resources';
+
+const panelStyle =
+  'fixed top-2 left-2 bg-black/70 text-white text-xs p-2 rounded shadow z-50';
+
+const VideoWallControlPanel: React.FC = () => {
+  const screens = useStore((s) => s.videoScreens);
+  const setVideoScreen = useStore((s) => s.setVideoScreen);
+
+  if (import.meta.env.VITE_DIRECTOR !== 'true') return null;
+
+  return (
+    <div className={panelStyle}>
+      {screens.map((screen) => (
+        <div
+          key={screen.id}
+          className="mb-2 last:mb-0 border-b last:border-b-0 border-white/20 pb-1"
+        >
+          <div className="font-bold mb-1">{screen.id}</div>
+          <select
+            value={screen.currentVideo}
+            onChange={(e) =>
+              setVideoScreen(screen.id, { currentVideo: e.target.value })
+            }
+            className="bg-gray-800 text-white text-xs rounded w-full mb-1"
+          >
+            <option value="" disabled>
+              選擇影片
+            </option>
+            {DIRECTOR_VIDEOS.map((v) => (
+              <option key={v} value={v}>
+                {v.split('/').pop()?.replace('.mp4', '')}
+              </option>
+            ))}
+          </select>
+          <label className="flex items-center space-x-1">
+            <input
+              type="checkbox"
+              checked={screen.visible}
+              onChange={(e) =>
+                setVideoScreen(screen.id, { visible: e.target.checked })
+              }
+            />
+            <span>顯示</span>
+          </label>
+          <div className="mt-1 text-[10px]">
+            {screen.visible ? screen.currentVideo.split('/').pop() : 'hidden'}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default VideoWallControlPanel;

--- a/prototype/frontend/src/components/__tests__/VideoPlayer.test.tsx
+++ b/prototype/frontend/src/components/__tests__/VideoPlayer.test.tsx
@@ -1,11 +1,12 @@
 import { render } from '@testing-library/react';
 import { Canvas } from '@react-three/fiber';
 import VideoPlayer from '../VideoPlayer';
+import { DANCE_VIDEOS } from '../../config/resources';
 
 test('renders VideoPlayer in Canvas', () => {
   render(
     <Canvas>
-      <VideoPlayer />
+      <VideoPlayer screenId="test" playlist={DANCE_VIDEOS.slice(0, 1)} />
     </Canvas>
   );
 });

--- a/prototype/frontend/src/store/slices/runtimeSlice.ts
+++ b/prototype/frontend/src/store/slices/runtimeSlice.ts
@@ -13,6 +13,15 @@ export interface RuntimeSlice {
   randomMode: boolean;
   fps: number;
   cpu: number;
+  videoScreens: {
+    id: string;
+    currentVideo: string;
+    visible: boolean;
+  }[];
+  setVideoScreen: (
+    id: string,
+    partial: Partial<{ id: string; currentVideo: string; visible: boolean }>
+  ) => void;
   setRuntime: (partial: Partial<RuntimeSlice>) => void;
 }
 
@@ -29,5 +38,16 @@ export const createRuntimeSlice: StateCreator<RuntimeSlice> = (set) => ({
   randomMode: true,
   fps: 0,
   cpu: 0,
+  videoScreens: [
+    { id: 'screen1', currentVideo: '', visible: false },
+    { id: 'screen2', currentVideo: '', visible: false },
+    { id: 'screen3', currentVideo: '', visible: false },
+  ],
+  setVideoScreen: (id, partial) =>
+    set((state) => ({
+      videoScreens: state.videoScreens.map((s) =>
+        s.id === id ? { ...s, ...partial } : s
+      ),
+    })),
   setRuntime: (partial) => set(partial),
 });


### PR DESCRIPTION
## Summary
- extend runtime slice with `videoScreens` array
- sync video state from `VideoPlayer` to new slice
- add `VideoWallControlPanel` for three-screen management
- update dynamic backgrounds and tests for screen IDs
- document control panel usage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test --silent` *(fails: react-scripts not found)*
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: EHOSTUNREACH)*