### PR TITLE
Implement backend-controlled audio and cue runner

### DIFF
--- a/prototype/backend/api/endpoints/control.py
+++ b/prototype/backend/api/endpoints/control.py
@@ -27,6 +27,10 @@ class PlayAudioRequest(BaseModel):
     url: str
     interrupt: Optional[bool] = False
 
+class BackgroundAudioRequest(BaseModel):
+    bgmUrl: Optional[str] = None
+    sfxUrl: Optional[str] = None
+
 class EmotionalTrajectoryRequest(BaseModel):
     duration: float
     keyframes: List[Dict[str, Any]]
@@ -133,6 +137,30 @@ async def play_audio_on_frontend(request: PlayAudioRequest):
     except Exception as e:
         logger.error(f"API 播放音頻失敗: {e}")
         raise HTTPException(status_code=500, detail=f"播放音頻失敗: {str(e)}")
+
+
+@router.post("/control/background-audio")
+async def background_audio_control(request: BackgroundAudioRequest):
+    """透過 API 控制背景音樂或音效"""
+    try:
+        if not manager.active_connections:
+            raise HTTPException(status_code=503, detail="沒有活動的前端連接")
+
+        audio_data: Dict[str, Any] = {"type": "audio-control"}
+        if request.bgmUrl:
+            audio_data["bgmUrl"] = request.bgmUrl
+        if request.sfxUrl:
+            audio_data["sfxUrl"] = request.sfxUrl
+
+        await manager.broadcast(json.dumps(audio_data))
+
+        logger.info(f"API 發送背景音訊控制: {audio_data}")
+
+        return {"success": True, "message": "背景音訊控制已發送"}
+
+    except Exception as e:
+        logger.error(f"API 發送背景音訊控制失敗: {e}")
+        raise HTTPException(status_code=500, detail=f"背景音訊控制失敗: {str(e)}")
 
 @router.post("/control/emotion-trajectory")
 async def send_emotion_trajectory(request: EmotionalTrajectoryRequest):

--- a/prototype/frontend/src/config/resources.ts
+++ b/prototype/frontend/src/config/resources.ts
@@ -205,10 +205,22 @@ export function createMixedPlaylist(categories: readonly (readonly string[])[], 
  * 取得完整的音頻檔案路徑
  */
 export function getBgmPath(filename: string): string {
+  if (filename.startsWith('http://') || filename.startsWith('https://')) {
+    return filename;
+  }
+  if (filename.startsWith('/')) {
+    return filename;
+  }
   return `${AUDIO_PATHS.BGM}${filename}`;
 }
 
 export function getEffectPath(filename: string): string {
+  if (filename.startsWith('http://') || filename.startsWith('https://')) {
+    return filename;
+  }
+  if (filename.startsWith('/')) {
+    return filename;
+  }
   return `${AUDIO_PATHS.EFFECTS}${filename}`;
 }
 

--- a/prototype/frontend/src/services/WebSocketService.ts
+++ b/prototype/frontend/src/services/WebSocketService.ts
@@ -176,6 +176,16 @@ class WebSocketService {
         useStore.getState().setRuntime((data as DirectorStateMessage).payload);
         return;
       }
+      if (data.type === 'audio-control') {
+        const payload = data as any;
+        if (payload.bgmUrl) {
+          useStore.getState().setRuntime({ bgm: payload.bgmUrl, bgmPlaying: true });
+        }
+        if (payload.sfxUrl) {
+          useStore.getState().setRuntime({ selectedEffect: payload.sfxUrl });
+        }
+        return;
+      }
       // --- 從高頻類型中移除 morph_update ---
       const highFrequencyTypes = ['animation_update']; // Remove 'morph_update'
 

--- a/prototype/shared/director/types.ts
+++ b/prototype/shared/director/types.ts
@@ -33,3 +33,13 @@ export interface DirectorStateMessage {
   type: 'director-state';
   payload: Partial<DirectorState>;
 }
+
+export interface AudioControlMessage {
+  type: 'audio-control';
+  bgmUrl?: string;
+  sfxUrl?: string;
+}
+
+export type DirectorWebSocketMessage =
+  | DirectorStateMessage
+  | AudioControlMessage;

--- a/scripts/cue_runner.py
+++ b/scripts/cue_runner.py
@@ -1,0 +1,30 @@
+import argparse
+import asyncio
+import json
+from pathlib import Path
+
+import yaml
+import websockets
+
+
+async def run_cues(path: Path, ws_url: str) -> None:
+    with path.open() as f:
+        cues = yaml.safe_load(f)
+    start = asyncio.get_event_loop().time()
+    async with websockets.connect(ws_url) as ws:
+        for cue in cues:
+            when = cue.get("time", 0)
+            await asyncio.sleep(max(0, start + when - asyncio.get_event_loop().time()))
+            await ws.send(json.dumps(cue.get("action", {})))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run cue sheet over WebSocket")
+    parser.add_argument("file", type=Path, help="Path to YAML/JSON cue sheet")
+    parser.add_argument("--ws", default="ws://localhost:8000/ws", help="WebSocket URL")
+    args = parser.parse_args()
+    asyncio.run(run_cues(args.file, args.ws))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/example_cues.yaml
+++ b/scripts/example_cues.yaml
@@ -1,0 +1,13 @@
+- time: 0
+  action:
+    type: director-state
+    payload:
+      lightingPreset: dramatic
+- time: 5
+  action:
+    type: audio-control
+    bgmUrl: /songs-assets/spacelive_theme.mp3
+- time: 10
+  action:
+    type: play-audio
+    url: /audio/sample_voice.mp3


### PR DESCRIPTION
## Summary
- support new `audio-control` WebSocket messages
- update frontend WebSocket service to handle BGM/SFX URLs
- allow absolute URLs for background audio resources
- expose `/control/background-audio` endpoint for backend control
- add simple cue-sheet runner script with example YAML

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npm run format` *(fails: Prettier config error)*
- `pytest` *(passes: no tests found)*
- `black .`
- `isort .`
- `mypy .` *(fails: songs_config module duplicate error)*
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683c4f8f395c83218e71c2f2d42e5bec