### PR TITLE
Implement backend-controlled audio and cue runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ space_live_project/
 `DirectorMonitorHUD` provides real-time state of BGM, SFX, video, lighting, camera and performance.
 Press **d** during runtime to expand the drawer view.
 
+### Murmur Mode
+
+Use the `murmur-mode` API to temporarily disable the self-talk feature when testing other functions.
+
+```bash
+curl -X POST http://localhost:8000/api/control/murmur-mode \
+  -H 'Content-Type: application/json' \
+  -d '{"enabled": false}'
+```
+
+Send `true` to re-enable murmurs.
+
 ## AI 代理流程
 
 本專案支援使用 AI 代理（如 Codex、Cursor、TaskMaster）進行自動化開發與維護。詳細的代理協作指南、分支策略、提交規範與自動化工作流程，請參考：

--- a/prototype/backend/api/endpoints/control.py
+++ b/prototype/backend/api/endpoints/control.py
@@ -1,12 +1,17 @@
+import asyncio
+import json
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from typing import Optional, Dict, Any, List
-import logging
-from ..endpoints.websocket import manager  # 導入 WebSocket 連接管理器
-import uuid
-import asyncio
-from datetime import datetime
-import json
+
+from ..endpoints.websocket import (  # 導入 WebSocket 連接管理器和 MurmurService
+    manager,
+    murmur_service,
+)
 
 # 設置日誌
 logger = logging.getLogger(__name__)
@@ -14,22 +19,36 @@ logger = logging.getLogger(__name__)
 # 創建路由
 router = APIRouter()
 
+
 # 定義請求模型
 class SendMessageRequest(BaseModel):
     content: str
     message_type: Optional[str] = "chat-message"
 
+
 class TriggerMurmurRequest(BaseModel):
     topic: Optional[str] = None
     force: Optional[bool] = False
+
 
 class PlayAudioRequest(BaseModel):
     url: str
     interrupt: Optional[bool] = False
 
+
+class BackgroundAudioRequest(BaseModel):
+    bgmUrl: Optional[str] = None
+    sfxUrl: Optional[str] = None
+
+
+class MurmurModeRequest(BaseModel):
+    enabled: bool
+
+
 class EmotionalTrajectoryRequest(BaseModel):
     duration: float
     keyframes: List[Dict[str, Any]]
+
 
 @router.post("/control/send-message")
 async def send_message_to_frontend(request: SendMessageRequest):
@@ -39,7 +58,7 @@ async def send_message_to_frontend(request: SendMessageRequest):
     try:
         if not manager.active_connections:
             raise HTTPException(status_code=503, detail="沒有活動的前端連接")
-        
+
         # 構建消息
         bot_message = {
             "id": f"api-bot-{int(asyncio.get_event_loop().time() * 1000)}",
@@ -47,28 +66,26 @@ async def send_message_to_frontend(request: SendMessageRequest):
             "content": request.content,
             "timestamp": datetime.utcnow().isoformat(),
             "audioUrl": None,
-            "isFromAPI": True  # 標記這是來自 API 的消息
+            "isFromAPI": True,  # 標記這是來自 API 的消息
         }
-        
+
         # 發送到所有連接的前端
-        message_data = {
-            "type": request.message_type,
-            "message": bot_message
-        }
-        
+        message_data = {"type": request.message_type, "message": bot_message}
+
         await manager.broadcast(json.dumps(message_data))
-        
+
         logger.info(f"API 發送消息到前端: {request.content}")
-        
+
         return {
             "success": True,
             "message": "消息已發送到前端",
-            "connections": len(manager.active_connections)
+            "connections": len(manager.active_connections),
         }
-    
+
     except Exception as e:
         logger.error(f"API 發送消息失敗: {e}")
         raise HTTPException(status_code=500, detail=f"發送消息失敗: {str(e)}")
+
 
 @router.post("/control/trigger-murmur")
 async def trigger_murmur(request: TriggerMurmurRequest):
@@ -78,30 +95,43 @@ async def trigger_murmur(request: TriggerMurmurRequest):
     try:
         if not manager.active_connections:
             raise HTTPException(status_code=503, detail="沒有活動的前端連接")
-        
+
         # 構建觸發消息 - 這裡我們可以向 WebSocket 發送一個特殊的觸發信號
         trigger_data = {
             "type": "trigger-murmur",
             "payload": {
                 "topic": request.topic,
                 "force": request.force,
-                "source": "api"
-            }
+                "source": "api",
+            },
         }
-        
+
         await manager.broadcast(json.dumps(trigger_data))
-        
+
         logger.info(f"API 觸發 murmur，主題: {request.topic}")
-        
+
         return {
             "success": True,
             "message": "murmur 觸發信號已發送",
-            "topic": request.topic
+            "topic": request.topic,
         }
-    
+
     except Exception as e:
         logger.error(f"API 觸發 murmur 失敗: {e}")
         raise HTTPException(status_code=500, detail=f"觸發 murmur 失敗: {str(e)}")
+
+
+@router.post("/control/murmur-mode")
+async def set_murmur_mode(request: MurmurModeRequest):
+    """啟用或停用 murmur 功能"""
+    try:
+        new_state = murmur_service.toggle_enabled(request.enabled)
+        logger.info(f"Murmur mode set to {new_state}")
+        return {"success": True, "enabled": new_state}
+    except Exception as e:
+        logger.error(f"API 切換 murmur 模式失敗: {e}")
+        raise HTTPException(status_code=500, detail=f"切換 murmur 模式失敗: {str(e)}")
+
 
 @router.post("/control/play-audio")
 async def play_audio_on_frontend(request: PlayAudioRequest):
@@ -111,28 +141,49 @@ async def play_audio_on_frontend(request: PlayAudioRequest):
     try:
         if not manager.active_connections:
             raise HTTPException(status_code=503, detail="沒有活動的前端連接")
-        
+
         # 構建音頻播放消息
         audio_data = {
             "type": "play-audio",
             "id": f"api-audio-{uuid.uuid4().hex[:8]}",
             "url": request.url,
-            "interrupt": request.interrupt
+            "interrupt": request.interrupt,
         }
-        
+
         await manager.broadcast(json.dumps(audio_data))
-        
+
         logger.info(f"API 觸發音頻播放: {request.url}")
-        
-        return {
-            "success": True,
-            "message": "音頻播放信號已發送",
-            "url": request.url
-        }
-    
+
+        return {"success": True, "message": "音頻播放信號已發送", "url": request.url}
+
     except Exception as e:
         logger.error(f"API 播放音頻失敗: {e}")
         raise HTTPException(status_code=500, detail=f"播放音頻失敗: {str(e)}")
+
+
+@router.post("/control/background-audio")
+async def background_audio_control(request: BackgroundAudioRequest):
+    """透過 API 控制背景音樂或音效"""
+    try:
+        if not manager.active_connections:
+            raise HTTPException(status_code=503, detail="沒有活動的前端連接")
+
+        audio_data: Dict[str, Any] = {"type": "audio-control"}
+        if request.bgmUrl:
+            audio_data["bgmUrl"] = request.bgmUrl
+        if request.sfxUrl:
+            audio_data["sfxUrl"] = request.sfxUrl
+
+        await manager.broadcast(json.dumps(audio_data))
+
+        logger.info(f"API 發送背景音訊控制: {audio_data}")
+
+        return {"success": True, "message": "背景音訊控制已發送"}
+
+    except Exception as e:
+        logger.error(f"API 發送背景音訊控制失敗: {e}")
+        raise HTTPException(status_code=500, detail=f"背景音訊控制失敗: {str(e)}")
+
 
 @router.post("/control/emotion-trajectory")
 async def send_emotion_trajectory(request: EmotionalTrajectoryRequest):
@@ -142,29 +193,27 @@ async def send_emotion_trajectory(request: EmotionalTrajectoryRequest):
     try:
         if not manager.active_connections:
             raise HTTPException(status_code=503, detail="沒有活動的前端連接")
-        
+
         # 構建情緒軌跡消息
         emotion_data = {
             "type": "emotionalTrajectory",
-            "payload": {
-                "duration": request.duration,
-                "keyframes": request.keyframes
-            }
+            "payload": {"duration": request.duration, "keyframes": request.keyframes},
         }
-        
+
         await manager.broadcast(json.dumps(emotion_data))
-        
+
         logger.info(f"API 發送情緒軌跡，時長: {request.duration}s")
-        
+
         return {
             "success": True,
             "message": "情緒軌跡已發送",
-            "duration": request.duration
+            "duration": request.duration,
         }
-    
+
     except Exception as e:
         logger.error(f"API 發送情緒軌跡失敗: {e}")
         raise HTTPException(status_code=500, detail=f"發送情緒軌跡失敗: {str(e)}")
+
 
 @router.get("/control/status")
 async def get_frontend_status():
@@ -176,8 +225,9 @@ async def get_frontend_status():
         "is_available": len(manager.active_connections) > 0,
         "connections_detail": [
             {"client": str(conn.client)} for conn in manager.active_connections
-        ]
+        ],
     }
+
 
 @router.post("/control/broadcast")
 async def broadcast_custom_message(message: Dict[str, Any]):
@@ -187,17 +237,17 @@ async def broadcast_custom_message(message: Dict[str, Any]):
     try:
         if not manager.active_connections:
             raise HTTPException(status_code=503, detail="沒有活動的前端連接")
-        
+
         await manager.broadcast(json.dumps(message))
-        
+
         logger.info(f"API 廣播自定義消息: {message.get('type', 'unknown')}")
-        
+
         return {
             "success": True,
             "message": "自定義消息已廣播",
-            "connections": len(manager.active_connections)
+            "connections": len(manager.active_connections),
         }
-    
+
     except Exception as e:
         logger.error(f"API 廣播消息失敗: {e}")
-        raise HTTPException(status_code=500, detail=f"廣播消息失敗: {str(e)}") 
+        raise HTTPException(status_code=500, detail=f"廣播消息失敗: {str(e)}")

--- a/prototype/backend/curl_examples.sh
+++ b/prototype/backend/curl_examples.sh
@@ -71,8 +71,17 @@ curl -X POST "$BASE_URL/control/broadcast" \
   }' | jq .
 echo
 
-# 7. 健康檢查
-echo "7. 健康檢查："
+# 7. 切換 murmur 模式
+echo "7. 切換 murmur 模式："
+curl -X POST "$BASE_URL/control/murmur-mode" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "enabled": false
+  }' | jq .
+echo
+
+# 8. 健康檢查
+echo "8. 健康檢查："
 curl -X GET "$BASE_URL/health" \
   -H "Content-Type: application/json" | jq .
 echo

--- a/prototype/frontend/src/config/resources.ts
+++ b/prototype/frontend/src/config/resources.ts
@@ -205,10 +205,22 @@ export function createMixedPlaylist(categories: readonly (readonly string[])[], 
  * 取得完整的音頻檔案路徑
  */
 export function getBgmPath(filename: string): string {
+  if (filename.startsWith('http://') || filename.startsWith('https://')) {
+    return filename;
+  }
+  if (filename.startsWith('/')) {
+    return filename;
+  }
   return `${AUDIO_PATHS.BGM}${filename}`;
 }
 
 export function getEffectPath(filename: string): string {
+  if (filename.startsWith('http://') || filename.startsWith('https://')) {
+    return filename;
+  }
+  if (filename.startsWith('/')) {
+    return filename;
+  }
   return `${AUDIO_PATHS.EFFECTS}${filename}`;
 }
 

--- a/prototype/frontend/src/services/WebSocketService.ts
+++ b/prototype/frontend/src/services/WebSocketService.ts
@@ -176,6 +176,16 @@ class WebSocketService {
         useStore.getState().setRuntime((data as DirectorStateMessage).payload);
         return;
       }
+      if (data.type === 'audio-control') {
+        const payload = data as any;
+        if (payload.bgmUrl) {
+          useStore.getState().setRuntime({ bgm: payload.bgmUrl, bgmPlaying: true });
+        }
+        if (payload.sfxUrl) {
+          useStore.getState().setRuntime({ selectedEffect: payload.sfxUrl });
+        }
+        return;
+      }
       // --- 從高頻類型中移除 morph_update ---
       const highFrequencyTypes = ['animation_update']; // Remove 'morph_update'
 

--- a/prototype/shared/director/types.ts
+++ b/prototype/shared/director/types.ts
@@ -33,3 +33,13 @@ export interface DirectorStateMessage {
   type: 'director-state';
   payload: Partial<DirectorState>;
 }
+
+export interface AudioControlMessage {
+  type: 'audio-control';
+  bgmUrl?: string;
+  sfxUrl?: string;
+}
+
+export type DirectorWebSocketMessage =
+  | DirectorStateMessage
+  | AudioControlMessage;

--- a/scripts/cue_runner.py
+++ b/scripts/cue_runner.py
@@ -1,0 +1,30 @@
+import argparse
+import asyncio
+import json
+from pathlib import Path
+
+import websockets
+import yaml
+
+
+async def run_cues(path: Path, ws_url: str) -> None:
+    with path.open() as f:
+        cues = yaml.safe_load(f)
+    start = asyncio.get_event_loop().time()
+    async with websockets.connect(ws_url) as ws:
+        for cue in cues:
+            when = cue.get("time", 0)
+            await asyncio.sleep(max(0, start + when - asyncio.get_event_loop().time()))
+            await ws.send(json.dumps(cue.get("action", {})))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run cue sheet over WebSocket")
+    parser.add_argument("file", type=Path, help="Path to YAML/JSON cue sheet")
+    parser.add_argument("--ws", default="ws://localhost:8000/ws", help="WebSocket URL")
+    args = parser.parse_args()
+    asyncio.run(run_cues(args.file, args.ws))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/example_cues.yaml
+++ b/scripts/example_cues.yaml
@@ -1,0 +1,13 @@
+- time: 0
+  action:
+    type: director-state
+    payload:
+      lightingPreset: dramatic
+- time: 5
+  action:
+    type: audio-control
+    bgmUrl: /songs-assets/spacelive_theme.mp3
+- time: 10
+  action:
+    type: play-audio
+    url: /audio/sample_voice.mp3


### PR DESCRIPTION
## Summary
- support new `audio-control` WebSocket messages
- update frontend WebSocket service to handle BGM/SFX URLs
- allow absolute URLs for background audio resources
- expose `/control/background-audio` endpoint for backend control
- add simple cue-sheet runner script with example YAML
- add murmur mode API toggle

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npm run format` *(fails: Prettier config error)*
- `pytest`
- `black .`
- `isort .`
- `mypy .` *(fails: songs_config module duplicate error)*
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683c4f8f395c83218e71c2f2d42e5bec