### PR TITLE
Add monitor control API

### DIFF
--- a/prototype/backend/api/__init__.py
+++ b/prototype/backend/api/__init__.py
@@ -8,7 +8,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.responses import FileResponse
 
 from .base import create_app
-from .endpoints import control, health, speech, websocket
+from .endpoints import control, health, monitors, speech, websocket
 from .middleware.cors import setup_cors
 
 # 設置日誌
@@ -38,6 +38,7 @@ def init_app() -> FastAPI:
     app.include_router(speech.router, prefix="/api", tags=["speech"])
     app.include_router(health.router, prefix="/api", tags=["system"])
     app.include_router(control.router, prefix="/api", tags=["control"])
+    app.include_router(monitors.router, prefix="/api", tags=["monitor"])
 
     # 創建音頻目錄（如果不存在）
     audio_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "audio")

--- a/prototype/backend/api/endpoints/monitors.py
+++ b/prototype/backend/api/endpoints/monitors.py
@@ -1,0 +1,59 @@
+import json
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from services.monitor_manager import monitor_manager
+
+from .websocket import manager
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class MonitorUpdateRequest(BaseModel):
+    visible: Optional[bool] = None
+    content: Optional[str] = None
+    playback_speed: Optional[float] = Field(None, alias="playbackSpeed")
+    volume: Optional[float] = None
+
+
+@router.get("/monitors")
+async def list_monitors():
+    """Return state of all monitors."""
+    return monitor_manager.list_states()
+
+
+@router.get("/monitors/{monitor_id}")
+async def get_monitor(monitor_id: str):
+    state = monitor_manager.get_state(monitor_id)
+    if not state:
+        raise HTTPException(status_code=404, detail="Monitor not found")
+    return state
+
+
+@router.put("/monitors/{monitor_id}")
+async def update_monitor(monitor_id: str, request: MonitorUpdateRequest):
+    try:
+        state = monitor_manager.update_state(
+            monitor_id,
+            visible=request.visible,
+            content=request.content,
+            playback_speed=request.playback_speed,
+            volume=request.volume,
+        )
+    except ValueError as e:
+        logger.error("Monitor update failed: %s", e)
+        raise HTTPException(status_code=400, detail=str(e))
+
+    await manager.broadcast(
+        json.dumps(
+            {
+                "type": "director-state",
+                "payload": {"videoScreens": monitor_manager.list_states()},
+            }
+        )
+    )
+    return state

--- a/prototype/backend/config/video_resources.py
+++ b/prototype/backend/config/video_resources.py
@@ -1,0 +1,42 @@
+# Video resource lists for backend validation
+
+DANCE_VIDEOS = [
+    "/videos/太空熱舞3.mp4",
+    "/videos/太空熱舞2.mp4",
+    "/videos/太空熱舞.mp4",
+    "/videos/太空辣妹跳舞.mp4",
+    "/videos/太空走秀.mp4",
+    "/videos/太空走秀2.mp4",
+]
+
+LIFESTYLE_VIDEOS = [
+    "/videos/太空瑜伽3.mp4",
+    "/videos/太空瑜伽2.mp4",
+    "/videos/太空瑜伽.mp4",
+    "/videos/太空直播中.mp4",
+    "/videos/太空泡水.mp4",
+    "/videos/太空化妝.mp4",
+    "/videos/太空打卡.mp4",
+    "/videos/太空打卡2.mp4",
+    "/videos/daily_life_1.mp4",
+]
+
+SPACE_EFFECT_VIDEOS = [
+    "/videos/火箭發射.mp4",
+    "/videos/星際小可愛.mp4",
+    "/videos/星際小籠包.mp4",
+    "/videos/星際聽音樂.mp4",
+    "/videos/黑洞.mp4",
+    "/videos/模擬星雲圖.mp4",
+    "/videos/太空巨乳.mp4",
+    "/videos/太空史萊姆.mp4",
+    "/videos/space_live_video_1.mp4",
+    "/videos/space_live.mp4",
+]
+
+ALL_VIDEOS = DANCE_VIDEOS + LIFESTYLE_VIDEOS + SPACE_EFFECT_VIDEOS
+
+
+def is_video_file_valid(filepath: str) -> bool:
+    """Return True if the provided video path exists in the known list."""
+    return filepath in ALL_VIDEOS

--- a/prototype/backend/services/monitor_manager.py
+++ b/prototype/backend/services/monitor_manager.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from config.video_resources import is_video_file_valid
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+class MonitorState(BaseModel):
+    id: str
+    currentVideo: str = ""
+    visible: bool = False
+    playing: bool = False
+    volume: float = 1.0
+    currentTime: float = 0.0
+    duration: float = 0.0
+    playbackRate: float = 1.0
+
+
+class MonitorManager:
+    """Manage state of frontend monitors."""
+
+    def __init__(self) -> None:
+        self.monitors: Dict[str, MonitorState] = {
+            f"screen{i}": MonitorState(id=f"screen{i}") for i in range(1, 4)
+        }
+
+    def get_state(self, monitor_id: str) -> Optional[MonitorState]:
+        return self.monitors.get(monitor_id)
+
+    def list_states(self) -> List[Dict[str, Any]]:
+        return [state.dict() for state in self.monitors.values()]
+
+    def update_state(
+        self,
+        monitor_id: str,
+        *,
+        visible: Optional[bool] = None,
+        content: Optional[str] = None,
+        playback_speed: Optional[float] = None,
+        volume: Optional[float] = None,
+    ) -> MonitorState:
+        if monitor_id not in self.monitors:
+            raise ValueError("Invalid monitor id")
+
+        state = self.monitors[monitor_id]
+
+        if content is not None:
+            if not is_video_file_valid(content):
+                raise ValueError(f"Unknown content id: {content}")
+            state.currentVideo = content
+            state.playing = True
+            state.visible = True
+            state.currentTime = 0.0
+
+        if visible is not None:
+            state.visible = visible
+            if not visible:
+                state.playing = False
+
+        if playback_speed is not None:
+            if not 0.25 <= playback_speed <= 4.0:
+                raise ValueError("playback speed must be between 0.25 and 4.0")
+            state.playbackRate = playback_speed
+
+        if volume is not None:
+            if not 0.0 <= volume <= 1.0:
+                raise ValueError("volume must be between 0.0 and 1.0")
+            state.volume = volume
+
+        logger.info("Monitor %s updated: %s", monitor_id, state.json())
+        return state
+
+
+monitor_manager = MonitorManager()


### PR DESCRIPTION
## Summary
- implement monitor control endpoints
- maintain monitor state and broadcast to WebSocket
- add backend lists for video validation

## Testing
- `black prototype/backend`
- `isort prototype/backend`
- `mypy prototype/backend`
- `pytest`
- `npm test` *(fails: react-scripts not found)*
- `npx markdownlint "**/*.md" --ignore node_modules` *(failed: command hung)*


------
https://chatgpt.com/codex/tasks/task_e_683e8cef6b988321b5783bb40a66ae2c