### PR TITLE
Add dancer animation control API

### DIFF
--- a/docs/backend/body_animation_api.md
+++ b/docs/backend/body_animation_api.md
@@ -1,0 +1,36 @@
+# Body Animation Control API
+
+後端提供此 API 以即時控制前端舞者動畫，包含單一動畫或動畫序列的播放、暫停與停止。
+
+## 端點一覽
+
+| 方法 | 路徑 | 說明 |
+|------|------|------|
+|`POST`|`/api/control/body-animation`|傳送舞者動畫指令|
+
+### 請求範例
+```bash
+curl -X POST http://localhost:8000/api/control/body-animation \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "state": "play",
+    "animation": "HipHopDance",
+    "loop": true,
+    "transitionDuration": 0.5
+  }'
+```
+
+### 參數說明
+- `state`：`play`、`pause`、`resume`、`stop` 之一。
+- `animation`：欲播放的單一動畫名稱。
+- `sequence`：若需播放多段動畫，提供 `{name, proportion}` 陣列。
+- `loop`：是否循環播放。
+- `loopCount`：循環次數，`null` 代表無限循環。
+- `speed`：播放速度倍率。
+- `transitionDuration`：動畫切換的淡入淡出時間（秒）。
+
+### 回應
+成功時回傳：
+```json
+{ "success": true }
+```

--- a/prototype/backend/api/endpoints/control.py
+++ b/prototype/backend/api/endpoints/control.py
@@ -8,13 +8,13 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from ..endpoints.websocket import (  # 導入 WebSocket 連接管理器和 MurmurService
-    manager,
-    murmur_service,
-    tts_service,
-    save_audio_and_set_url as save_websocket_audio,
-)
 from services.camera_control import CameraControlService
+
+from ..endpoints.websocket import manager, murmur_service
+from ..endpoints.websocket import (
+    save_audio_and_set_url as save_websocket_audio,
+)  # 導入 WebSocket 連接管理器和 MurmurService
+from ..endpoints.websocket import tts_service
 
 # 設置日誌
 logger = logging.getLogger(__name__)
@@ -73,6 +73,18 @@ class CameraPresetRequest(CameraAngles):
     name: str
 
 
+class BodyAnimationCommand(BaseModel):
+    """Request model for controlling body animations."""
+
+    state: Optional[str] = "play"
+    animation: Optional[str] = None
+    sequence: Optional[List[Dict[str, Any]]] = None
+    loop: Optional[bool] = None
+    loopCount: Optional[int] = None
+    speed: Optional[float] = None
+    transitionDuration: Optional[float] = None
+
+
 @router.post("/control/send-message")
 async def send_message_to_frontend(request: SendMessageRequest):
     """
@@ -84,21 +96,31 @@ async def send_message_to_frontend(request: SendMessageRequest):
 
         audio_url_for_message = None
         if request.content:
-            logger.info(f"API /send-message: 正在為內容進行 TTS: '{request.content[:30]}...'")
+            logger.info(
+                f"API /send-message: 正在為內容進行 TTS: '{request.content[:30]}...'"
+            )
             tts_result = await tts_service.synthesize_speech(request.content)
             if tts_result and tts_result.get("audio"):
                 audio_base64 = tts_result.get("audio")
                 temp_message_obj_for_audio = {
                     "id": f"api-tts-{uuid.uuid4().hex[:8]}",
                 }
-                await save_websocket_audio(audio_base64, temp_message_obj_for_audio, is_murmur=False)
+                await save_websocket_audio(
+                    audio_base64, temp_message_obj_for_audio, is_murmur=False
+                )
                 audio_url_for_message = temp_message_obj_for_audio.get("audioUrl")
                 if audio_url_for_message:
-                    logger.info(f"API /send-message: TTS 成功，音訊 URL: {audio_url_for_message}")
+                    logger.info(
+                        f"API /send-message: TTS 成功，音訊 URL: {audio_url_for_message}"
+                    )
                 else:
-                    logger.warning("API /send-message: save_websocket_audio 未能生成 audioUrl")
+                    logger.warning(
+                        "API /send-message: save_websocket_audio 未能生成 audioUrl"
+                    )
             else:
-                logger.warning(f"API /send-message: TTS 失敗或未返回音訊內容 for: '{request.content[:30]}...'")
+                logger.warning(
+                    f"API /send-message: TTS 失敗或未返回音訊內容 for: '{request.content[:30]}...'"
+                )
 
         bot_message = {
             "id": f"api-bot-{int(asyncio.get_event_loop().time() * 1000)}",
@@ -342,4 +364,17 @@ async def load_camera_preset(name: str, duration: float = 1.0):
     message = {"type": "camera-transition", "payload": payload}
     await manager.broadcast(json.dumps(message))
     logger.info(f"Loaded camera preset: {name}")
+    return {"success": True}
+
+
+@router.post("/control/body-animation")
+async def control_body_animation(command: BodyAnimationCommand):
+    """Broadcast body animation commands to the frontend."""
+    if not manager.active_connections:
+        raise HTTPException(status_code=503, detail="沒有活動的前端連接")
+
+    payload = {k: v for k, v in command.dict().items() if v is not None}
+    message = {"type": "body-animation", "payload": payload}
+    await manager.broadcast(json.dumps(message))
+    logger.info(f"Broadcast body animation command: {payload}")
     return {"success": True}

--- a/prototype/frontend/src/services/WebSocketService.ts
+++ b/prototype/frontend/src/services/WebSocketService.ts
@@ -292,6 +292,24 @@ class WebSocketService {
         );
         // --- 日誌記錄結束 ---
         // (可以保留特定處理邏輯，但狀態已更新)
+      } else if (data.type === "body-animation") {
+        const payload: any = (data as any).payload || {};
+        if (Array.isArray(payload.sequence)) {
+          useStore.getState().setAnimationSequence(payload.sequence);
+          if (!payload.state || payload.state === "play") {
+            useStore.getState().startSequencePlayback();
+          }
+        } else if (payload.animation) {
+          useStore.getState().setCurrentAnimation(payload.animation);
+        }
+
+        if (payload.state === "stop") {
+          useStore.getState().stopSequencePlayback();
+        } else if (payload.state === "pause") {
+          useStore.getState().pauseSequencePlayback();
+        } else if (payload.state === "resume") {
+          useStore.getState().resumeSequencePlayback();
+        }
       } else if (data.type && highFrequencyTypes.includes(data.type)) {
         this._handleHighFrequencyMessage(data.type, data);
       } else {


### PR DESCRIPTION
## Summary
- add REST endpoint to broadcast dancer animation commands
- handle `body-animation` messages on the frontend
- document the new animation control API

## Testing
- `black api/endpoints/control.py`
- `isort api/endpoints/control.py`
- `mypy api/endpoints/control.py` *(failed: missing stubs and other errors)*
- `npx eslint src/services/WebSocketService.ts` *(failed: missing dependencies)*
- `npm test` *(failed: react-scripts not found)*
- `pytest` *(no tests found)*
- `npx markdownlint body_animation_api.md`

------
https://chatgpt.com/codex/tasks/task_e_683e99869ad08321801f2a327d91c707