### PR TITLE
Add experimental scripts for Cursor API

### DIFF
--- a/prototype/backend/experiment_scripts/cosmic_horror.sh
+++ b/prototype/backend/experiment_scripts/cosmic_horror.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# 實驗腳本: 宇宙恐怖降臨
+# 展示極端鏡位與恐懼情緒
+
+BASE_URL="http://localhost:8000/api"
+
+echo "=== 宇宙恐怖降臨 ==="
+
+# 關閉 murmur 並停用隨機鏡頭
+curl -X POST "$BASE_URL/control/murmur-mode" -H "Content-Type: application/json" -d '{"enabled": false}' | jq .
+curl -X POST "$BASE_URL/control/broadcast" -H "Content-Type: application/json" -d '{"type": "director-state", "payload": {"randomMode": false}}' | jq .
+
+# 幽暗 BGM 與風聲
+curl -X POST "$BASE_URL/control/background-audio" \
+  -H "Content-Type: application/json" \
+  -d '{"bgmUrl": "/audio/BGM/spacelive_theme.mp3", "sfxUrl": "/audio/effects/winds_blowing.mp3", "bgmVolume": 0.4, "sfxVolume": 0.5}' | jq .
+
+sleep 1
+
+# 螢幕1播放黑洞
+curl -X PUT "$BASE_URL/monitors/screen1" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "/videos/黑洞.mp4", "visible": true, "playing": true, "volume": 0.7}' | jq .
+
+sleep 1
+
+# 初始鏡位
+curl -X POST "$BASE_URL/control/camera/set-angle" \
+  -H "Content-Type: application/json" \
+  -d '{"pitch": -5, "yaw": -20, "roll": 0}' | jq .
+
+sleep 1
+
+# 恐懼獨白
+curl -X POST "$BASE_URL/control/send-message" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "我感受到來自宇宙深處的低語… 不祥的預兆在逼近。"}' | jq .
+
+curl -X POST "$BASE_URL/control/emotion-trajectory" \
+  -H "Content-Type: application/json" \
+  -d '{"duration": 4.0, "keyframes": [{"tag": "fear", "proportion": 0.0}, {"tag": "shocked", "proportion": 1.0}]}' | jq .
+
+sleep 5
+
+# 暴龍吼叫音效
+curl -X POST "$BASE_URL/control/play-audio" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "/songs-file/暴龍吼叫.mp3", "volume": 0.5}' | jq .
+
+sleep 1
+
+# 荷蘭角鏡位
+curl -X POST "$BASE_URL/control/camera/transition" \
+  -H "Content-Type: application/json" \
+  -d '{"pitch": 15, "yaw": 40, "roll": 45, "duration": 2.5}' | jq .
+
+sleep 3
+
+# 驚恐步伐動畫
+curl -X POST "$BASE_URL/control/body-animation" \
+  -H "Content-Type: application/json" \
+  -d '{"animation_id": "InjuredWalk", "loop": false}' | jq .
+
+sleep 6
+
+# 撤離宣告
+curl -X POST "$BASE_URL/control/send-message" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "黑暗正在侵蝕這片空間，我們必須撤離！"}' | jq .
+
+curl -X POST "$BASE_URL/control/emotion-trajectory" \
+  -H "Content-Type: application/json" \
+  -d '{"duration": 3.0, "keyframes": [{"tag": "fear", "proportion": 0.0}, {"tag": "panic", "proportion": 1.0}]}' | jq .
+
+sleep 5

--- a/prototype/backend/experiment_scripts/duet_drama.sh
+++ b/prototype/backend/experiment_scripts/duet_drama.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# 實驗腳本: 雙人對話劇
+# 展示多角色對話與鏡位切換
+
+BASE_URL="http://localhost:8000/api"
+
+echo "=== 雙人對話劇 ==="
+
+# 柔和背景音樂
+curl -X POST "$BASE_URL/control/background-audio" \
+  -H "Content-Type: application/json" \
+  -d '{"bgmUrl": "/audio/BGM/spacelive_theme2.mp3", "bgmVolume": 0.4}' | jq .
+
+sleep 1
+
+# A 登場
+curl -X POST "$BASE_URL/control/send-message" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "A: 你好，B。我們終於在這片星空下相遇。"}' | jq .
+
+curl -X POST "$BASE_URL/control/emotion-trajectory" \
+  -H "Content-Type: application/json" \
+  -d '{"duration": 3.0, "keyframes": [{"tag": "happy", "proportion": 0.0}, {"tag": "interested", "proportion": 1.0}]}' | jq .
+
+sleep 4
+
+# 切換至 B 的視角
+curl -X POST "$BASE_URL/control/camera/transition" \
+  -H "Content-Type: application/json" \
+  -d '{"pitch": 5, "yaw": -20, "roll": 0, "duration": 2.0}' | jq .
+
+sleep 2
+
+# B 回應
+curl -X POST "$BASE_URL/control/send-message" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "B: A，是命運指引我們到此，還是巧合？"}' | jq .
+
+curl -X POST "$BASE_URL/control/emotion-trajectory" \
+  -H "Content-Type: application/json" \
+  -d '{"duration": 3.0, "keyframes": [{"tag": "confused", "proportion": 0.0}, {"tag": "thoughtful", "proportion": 1.0}]}' | jq .
+
+sleep 4
+
+# 鏡頭再次轉換
+curl -X POST "$BASE_URL/control/camera/transition" \
+  -H "Content-Type: application/json" \
+  -d '{"pitch": 0, "yaw": 20, "roll": 0, "duration": 2.0}' | jq .
+
+sleep 2
+
+# 動作表示和解
+curl -X POST "$BASE_URL/control/body-animation" \
+  -H "Content-Type: application/json" \
+  -d '{"animation_id": "FemaleStandingPose", "loop": false}' | jq .
+
+sleep 2
+
+# A 的決心
+curl -X POST "$BASE_URL/control/send-message" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "A: 不論答案如何，讓我們共同完成這段旅程。"}' | jq .
+
+curl -X POST "$BASE_URL/control/emotion-trajectory" \
+  -H "Content-Type: application/json" \
+  -d '{"duration": 4.0, "keyframes": [{"tag": "happy", "proportion": 0.0}, {"tag": "joyful", "proportion": 1.0}]}' | jq .
+
+sleep 5
+
+# 鏡頭緩緩拉遠
+curl -X POST "$BASE_URL/control/camera/transition" \
+  -H "Content-Type: application/json" \
+  -d '{"pitch": -5, "yaw": 0, "roll": 0, "duration": 3.0}' | jq .
+
+sleep 3

--- a/prototype/backend/experiment_scripts/emergency_protocol.sh
+++ b/prototype/backend/experiment_scripts/emergency_protocol.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# 實驗腳本: 緊急撤離程序
+# 高張力警報場景
+
+BASE_URL="http://localhost:8000/api"
+
+echo "=== 緊急撤離程序啟動 ==="
+
+# 停用隨機鏡位
+curl -X POST "$BASE_URL/control/broadcast" \
+  -H "Content-Type: application/json" \
+  -d '{"type": "director-state", "payload": {"randomMode": false}}' | jq .
+
+# 警報 BGM 及快節奏音效
+curl -X POST "$BASE_URL/control/background-audio" \
+  -H "Content-Type: application/json" \
+  -d '{"bgmUrl": "/audio/BGM/heavy_metal_bgm_01.mp3", "sfxUrl": "/audio/effects/Energetic_fast_pace.mp3"}' | jq .
+
+sleep 1
+
+# 螢幕顯示警告圖像
+curl -X PUT "$BASE_URL/monitors/screen1" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "/videos/模擬星雲圖.mp4", "visible": true, "playing": true, "volume": 0.9}' | jq .
+
+sleep 1
+
+# 發出警告台詞
+curl -X POST "$BASE_URL/control/send-message" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "警報！系統檢測到未知能量衝擊，請立即撤離！"}' | jq .
+
+curl -X POST "$BASE_URL/control/emotion-trajectory" \
+  -H "Content-Type: application/json" \
+  -d '{"duration": 3.0, "keyframes": [{"tag": "panic", "proportion": 0.0}, {"tag": "fear", "proportion": 1.0}]}' | jq .
+
+sleep 4
+
+# 激烈鏡位切換
+curl -X POST "$BASE_URL/control/camera/transition" \
+  -H "Content-Type: application/json" \
+  -d '{"pitch": 20, "yaw": -30, "roll": -20, "duration": 1.5}' | jq .
+
+sleep 2
+
+# 閃避動作
+curl -X POST "$BASE_URL/control/body-animation" \
+  -H "Content-Type: application/json" \
+  -d '{"animation_id": "AerialEvade", "loop": false}' | jq .
+
+sleep 5
+
+# 播放警示音
+curl -X POST "$BASE_URL/control/play-audio" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "/songs-file/暴龍吼叫.mp3", "interrupt": false}' | jq .
+
+sleep 3
+
+# 終極撤離指令
+curl -X POST "$BASE_URL/control/send-message" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "所有人員請就位，準備啟動緊急逃生艙！"}' | jq .
+
+curl -X POST "$BASE_URL/control/emotion-trajectory" \
+  -H "Content-Type: application/json" \
+  -d '{"duration": 4.0, "keyframes": [{"tag": "fear", "proportion": 0.0}, {"tag": "determined", "proportion": 1.0}]}' | jq .
+
+sleep 5

--- a/prototype/backend/experiment_scripts/game_show_mania.sh
+++ b/prototype/backend/experiment_scripts/game_show_mania.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# 實驗腳本: 星際綜藝遊戲秀
+# 快節奏互動與搞笑鏡位
+
+BASE_URL="http://localhost:8000/api"
+
+echo "=== 星際綜藝遊戲秀開場 ==="
+
+# 熱鬧 BGM 與效果音
+curl -X POST "$BASE_URL/control/background-audio" \
+  -H "Content-Type: application/json" \
+  -d '{"bgmUrl": "/audio/BGM/spacelive_theme.mp3", "sfxUrl": "/audio/effects/taiwan_variety_sfx_01.mp3"}' | jq .
+
+sleep 1
+
+# 標準主持人鏡位
+curl -X POST "$BASE_URL/control/camera/set-angle" \
+  -H "Content-Type: application/json" \
+  -d '{"pitch": 0, "yaw": 0, "roll": 0}' | jq .
+
+sleep 1
+
+# 螢幕1顯示節目畫面
+curl -X PUT "$BASE_URL/monitors/screen1" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "/videos/太空直播中.mp4", "visible": true, "playing": true, "volume": 0}' | jq .
+
+sleep 1
+
+# 熱情歡迎詞
+curl -X POST "$BASE_URL/control/send-message" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "歡迎來到星際綜藝！今天的競賽即將開始～"}' | jq .
+
+curl -X POST "$BASE_URL/control/emotion-trajectory" \
+  -H "Content-Type: application/json" \
+  -d '{"duration": 3.0, "keyframes": [{"tag": "happy", "proportion": 0.0}, {"tag": "joyful", "proportion": 1.0}]}' | jq .
+
+sleep 4
+
+# 動感鏡位切換
+curl -X POST "$BASE_URL/control/camera/transition" \
+  -H "Content-Type: application/json" \
+  -d '{"pitch": -10, "yaw": 25, "roll": 0, "duration": 2.0}' | jq .
+
+sleep 2
+
+# 歡呼音效
+curl -X POST "$BASE_URL/control/play-audio" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "/songs-file/鳥叫.mp3", "volume": 0.2}' | jq .
+
+sleep 1
+
+# Flair 動畫炒熱氣氛
+curl -X POST "$BASE_URL/control/body-animation" \
+  -H "Content-Type: application/json" \
+  -d '{"animation_id": "Flair", "loop": false}' | jq .
+
+sleep 3
+
+# 螢幕2顯示計分板
+curl -X PUT "$BASE_URL/monitors/screen2" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "/videos/太空瑜伽.mp4", "visible": true, "playing": true, "volume": 0.3}' | jq .
+
+sleep 5
+
+# 360 度鏡位炫技
+curl -X POST "$BASE_URL/control/camera/transition" \
+  -H "Content-Type: application/json" \
+  -d '{"pitch": 0, "yaw": 360, "roll": 0, "duration": 4.0}' | jq .
+
+sleep 4
+
+# 結束致詞
+curl -X POST "$BASE_URL/control/send-message" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "恭喜參賽者獲勝！感謝各位觀眾收看，下次再會～"}' | jq .
+
+curl -X POST "$BASE_URL/control/emotion-trajectory" \
+  -H "Content-Type: application/json" \
+  -d '{"duration": 3.0, "keyframes": [{"tag": "happy", "proportion": 0.0}, {"tag": "joyful", "proportion": 1.0}]}' | jq .
+
+sleep 5

--- a/prototype/backend/experiment_scripts/starry_romance.sh
+++ b/prototype/backend/experiment_scripts/starry_romance.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# 實驗腳本: 星光浪漫之夜
+# 柔和鏡位與浪漫情緒
+
+BASE_URL="http://localhost:8000/api"
+
+echo "=== 星光浪漫之夜 ==="
+
+# 播放浪漫 BGM 與微風
+curl -X POST "$BASE_URL/control/background-audio" \
+  -H "Content-Type: application/json" \
+  -d '{"bgmUrl": "/audio/BGM/space_live_country_theme1.mp3", "sfxUrl": "/audio/effects/winds_blowing.mp3", "bgmVolume": 0.5, "sfxVolume": 0.2}' | jq .
+
+sleep 1
+
+# 緩慢抬頭望向星空
+curl -X POST "$BASE_URL/control/camera/transition" \
+  -H "Content-Type: application/json" \
+  -d '{"pitch": -10, "yaw": 15, "roll": 0, "duration": 3.0}' | jq .
+
+sleep 2
+
+# 溫柔台詞與情緒
+curl -X POST "$BASE_URL/control/send-message" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "在滿天星斗下，讓我們靜靜感受彼此的心跳。"}' | jq .
+
+curl -X POST "$BASE_URL/control/emotion-trajectory" \
+  -H "Content-Type: application/json" \
+  -d '{"duration": 4.0, "keyframes": [{"tag": "shy", "proportion": 0.0}, {"tag": "happy", "proportion": 1.0}]}' | jq .
+
+sleep 5
+
+# 角色開心舞動
+curl -X POST "$BASE_URL/control/body-animation" \
+  -H "Content-Type: application/json" \
+  -d '{"animation_id": "Happy", "loop": true}' | jq .
+
+sleep 2
+
+# 螢幕2播放浪漫影片
+curl -X PUT "$BASE_URL/monitors/screen2" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "/videos/太空瑜伽.mp4", "visible": true, "playing": true, "volume": 0.2}' | jq .
+
+sleep 5
+
+# 鳥鳴音效
+curl -X POST "$BASE_URL/control/play-audio" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "/songs-file/鳥叫.mp3", "volume": 0.1}' | jq .
+
+sleep 3
+
+# 鏡頭回到溫柔正面
+curl -X POST "$BASE_URL/control/camera/transition" \
+  -H "Content-Type: application/json" \
+  -d '{"pitch": -5, "yaw": 0, "roll": 0, "duration": 2.0}' | jq .
+
+sleep 2
+
+# 告白台詞
+curl -X POST "$BASE_URL/control/send-message" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "願這片星海見證我們的故事。"}' | jq .
+
+curl -X POST "$BASE_URL/control/emotion-trajectory" \
+  -H "Content-Type: application/json" \
+  -d '{"duration": 4.0, "keyframes": [{"tag": "happy", "proportion": 0.0}, {"tag": "joyful", "proportion": 1.0}]}' | jq .
+
+sleep 5


### PR DESCRIPTION
## Summary
- add 5 imaginative shell scripts demonstrating Cursor API usage

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest`
- `npx markdownlint` *(fails: 403 Forbidden to download package)*

------
https://chatgpt.com/codex/tasks/task_e_6840419729d08321a2df04aa4f4032e3