### PR TITLE
Implement API for frontend camera presets

### DIFF
--- a/docs/backend/camera_control_api.md
+++ b/docs/backend/camera_control_api.md
@@ -14,6 +14,31 @@
 
 所有角度以 **度** 為單位。`transition` 與 `load-preset` 端點可透過 `duration` 參數調整過渡時間。
 
+## 可用的前端相機預設
+
+以下是前端 `resources.ts` 中定義的可用相機預設名稱列表，可供 `/api/control/camera/set-frontend-preset` 端點使用：
+
+- `overview`
+- `head_close_up`
+- `dance_circle_view`
+- `side_view`
+- `low_angle_head`
+- `center_orbit_high_1`
+- `center_orbit_high_2`
+- `center_orbit_low_1`
+- `center_orbit_low_2`
+- `top_down_center`
+- `dramatic_angle_1`
+- `dramatic_angle_2`
+- `behind_head_looking_out`
+- `fly_by_left`
+- `fly_by_right`
+- `frontal_dynamic_low`
+- `frontal_dynamic_high`
+- `orbit_head_1`
+- `orbit_head_2`
+- `full_shot_dancers`
+
 ### 範例請求
 
 ```bash
@@ -23,11 +48,11 @@ curl -X POST \
   -d '{"pitch": 0, "yaw": 45, "roll": 0}'
 ```
 
-切換前端至名為 `overview` 的鏡位：
+命令前端切換至名為 `head_close_up` 的鏡位，過渡時間 2.5 秒：
 
 ```bash
 curl -X POST \
   http://localhost:8000/api/control/camera/set-frontend-preset \
   -H 'Content-Type: application/json' \
-  -d '{"name": "overview", "duration": 5.0}'
+  -d '{"name": "head_close_up", "duration": 2.5}'
 ```

--- a/docs/backend/camera_control_api.md
+++ b/docs/backend/camera_control_api.md
@@ -10,6 +10,7 @@
 |`POST`|`/api/control/camera/transition`|在指定時間內平滑轉換至目標角度|
 |`POST`|`/api/control/camera/save-preset`|儲存或更新一組自定義相機預設|
 |`POST`|`/api/control/camera/load-preset`|載入先前儲存的預設並套用到前端|
+|`POST`|`/api/control/camera/set-frontend-preset`|命令前端切換到指定的相機預設|
 
 所有角度以 **度** 為單位。`transition` 與 `load-preset` 端點可透過 `duration` 參數調整過渡時間。
 
@@ -20,4 +21,13 @@ curl -X POST \
   http://localhost:8000/api/control/camera/set-angle \
   -H 'Content-Type: application/json' \
   -d '{"pitch": 0, "yaw": 45, "roll": 0}'
+```
+
+切換前端至名為 `overview` 的鏡位：
+
+```bash
+curl -X POST \
+  http://localhost:8000/api/control/camera/set-frontend-preset \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "overview", "duration": 5.0}'
 ```

--- a/docs/backend/cursor_api_control_response_guidelines.md
+++ b/docs/backend/cursor_api_control_response_guidelines.md
@@ -30,6 +30,7 @@ The application registers these routes in `prototype/backend/api/__init__.py`.
 |`POST`|`/api/control/camera/transition`|Smoothly transition the camera orientation.|
 |`POST`|`/api/control/camera/save-preset`|Save a camera preset on the server.|
 |`POST`|`/api/control/camera/load-preset`|Load a stored camera preset.|
+|`POST`|`/api/control/camera/set-frontend-preset`|Command frontend to switch to a named camera preset.|
 |`POST`|`/api/control/body-animation`|Control body animation states.|
 
 The request models for these routes are defined at the top of `control.py` and include fields such as `content`, `url`, `duration`, `keyframes`, and camera angles.
@@ -56,7 +57,7 @@ The request models for these routes are defined at the top of `control.py` and i
 A websocket endpoint at `/ws` provides real-time conversation handling. It manages queues, playback acknowledgements and murmur logic.
 
 ## Mapping User Instructions
-1. **Direct control commands** – map explicit directives such as "play this audio" or "set camera angle" to the corresponding control endpoint.
+1. **Direct control commands** – map explicit directives such as "play this audio", "set camera angle", or "switch to overview camera" to the corresponding control endpoint (e.g., `/api/control/camera/set-frontend-preset` for named camera views).
 2. **Monitor operations** – interpret requests about changing monitor visibility, content or volume and call the monitor endpoints.
 3. **Speech processing** – when users supply audio to convert or ask for generated speech, use the speech endpoints.
 4. **Status queries** – requests for availability or connection information should call `/api/control/status` or `/api/health`.
@@ -186,6 +187,14 @@ To help Cursor better understand and utilize project assets, here are some key p
 }
 ```
 
+**8. Set Frontend Camera Preset (`/api/control/camera/set-frontend-preset`)**
+```json
+{
+  "name": "string (Name of the camera preset defined in frontend, e.g., 'overview', 'head_close_up', required)",
+  "duration": "float (Optional, transition duration in seconds, default by backend implementation, e.g., 5.0s)"
+}
+```
+
 ## 🎉 Best Practices for a Smooth Show! 🎉
 
 1.  **Always Verify Connection Status First!**
@@ -228,6 +237,10 @@ To help Cursor better understand and utilize project assets, here are some key p
     -   If a `send-message` is followed by many other visual or audio commands, the TTS might get "swamped" or its initiation might fail.
     -   **Consider adding short `sleep` pauses (e.g., `sleep 0.5` to `sleep 2.0`) immediately after `send-message` and its paired `emotion-trajectory` *before* a rapid sequence of other commands.** This gives the TTS system a moment to initialize.
     -   Also, ensure that complex scenes have fully resolved (with adequate `sleep` at the end of their command block) before initiating new scenes, especially new `send-message` commands. This prevents a backlog or resource contention on the frontend/backend.
+
+11. **Validate Frontend Preset Names:**
+    -   When using `/api/control/camera/set-frontend-preset`, ensure the `name` provided corresponds to a camera preset defined in the frontend's configuration (e.g., in `prototype/frontend/src/config/resources.ts`). Sending an unknown preset name will likely result in no camera change or an error/warning on the frontend side.
+    -   Refer to `docs/backend/camera_control_api.md` for a list of known presets populated from the frontend configuration.
 
 ##🎬 Working Examples: Bringing it All Together
 
@@ -276,6 +289,15 @@ curl -X POST http://localhost:8000/api/control/camera/transition \
 curl -X PUT http://localhost:8000/api/monitors/screen1 \
   -H "Content-Type: application/json" \
   -d '{"content": "/videos/太空瑜伽.mp4", "visible": true, "playing": true, "volume": 0.8}'
+```
+
+**Example 4: Command Frontend to Switch Camera Preset**
+```bash
+# This tells the frontend to use its own 'side_view' preset definition,
+# with a 2-second transition.
+curl -X POST http://localhost:8000/api/control/camera/set-frontend-preset \\
+  -H "Content-Type: application/json" \\
+  -d '{"name": "side_view", "duration": 2.0}'
 ```
 
 ## 🔍 Troubleshooting Common Issues

--- a/prototype/backend/api/endpoints/control.py
+++ b/prototype/backend/api/endpoints/control.py
@@ -74,6 +74,13 @@ class CameraPresetRequest(CameraAngles):
     name: str
 
 
+class FrontendPresetRequest(BaseModel):
+    """Request model for directly loading a frontend camera preset."""
+
+    name: str
+    duration: float = 5.0
+
+
 class BodyAnimationCommand(BaseModel):
     """Request model for controlling body animations."""
 
@@ -378,6 +385,21 @@ async def load_camera_preset(name: str, duration: float = 1.0):
     message = {"type": "camera-transition", "payload": payload}
     await manager.broadcast(json.dumps(message))
     logger.info(f"Loaded camera preset: {name}")
+    return {"success": True}
+
+
+@router.post("/control/camera/set-frontend-preset")
+async def set_frontend_camera_preset(request: FrontendPresetRequest):
+    """Broadcast a preset name to the frontend for direct loading."""
+    if not request.name:
+        raise HTTPException(status_code=422, detail="Preset name required")
+    if not manager.active_connections:
+        raise HTTPException(status_code=503, detail="沒有活動的前端連接")
+
+    payload = {"name": request.name, "duration": request.duration}
+    message = {"type": "set-frontend-camera-preset", "payload": payload}
+    await manager.broadcast(json.dumps(message))
+    logger.info(f"Broadcast frontend camera preset: {payload}")
     return {"success": True}
 
 

--- a/prototype/backend/experiment_scripts/meta_self.sh
+++ b/prototype/backend/experiment_scripts/meta_self.sh
@@ -18,6 +18,17 @@ echo "準備工作：確保一個乾淨的拍攝環境..."
 
 sleep 1
 
+# 設定初始預設鏡位為 overview
+echo "設定初始預設鏡位為 overview..."
+curl -X POST "$BASE_URL/control/camera/set-frontend-preset" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "overview",
+    "duration": 2.0
+  }'
+echo "初始鏡位設定完成，等待2秒..."
+sleep 2
+
 # --- 第一幕：意識的微光 ---
 echo "=== 第一幕：意識的微光 ==="
 echo "場景：混沌初開 - 虛無中的脈動"
@@ -63,6 +74,16 @@ curl -X PUT "$BASE_URL/monitors/screen1" \
   }'
 sleep 1 # 等待影片開始播放
 
+echo "切換至 head_close_up 鏡位進行獨白..."
+curl -X POST "$BASE_URL/control/camera/set-frontend-preset" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "head_close_up",
+    "duration": 2.0
+  }'
+echo "head_close_up 鏡位設定完成，等待2秒讓鏡頭到位..."
+sleep 2
+
 echo "伊始之眼的獨白 - 第一次呼吸..."
 curl -X POST "$BASE_URL/control/send-message" \
   -H "Content-Type: application/json" \
@@ -82,7 +103,6 @@ curl -X POST "$BASE_URL/control/emotion-trajectory" \
     ]
   }'
 sleep 1 # 情感表達開始後
-
 
 sleep 4 # 等待獨白和情感表達完成，音效會短暫播放
 
@@ -143,6 +163,19 @@ curl -X PUT "$BASE_URL/monitors/screen1" \
     "volume": 0.7
   }'
 sleep 3 # 等待台詞、情感和鏡頭轉換完成，並讓影片播放一會兒
+
+echo "切換至低角度鏡頭，觀察整體姿態..."
+curl -X POST "$BASE_URL/control/camera/transition" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pitch": 30,
+    "yaw": 0,
+    "roll": 0,
+    "fov": 60,
+    "duration": 2.0
+  }'
+echo "低角度鏡頭設定完成，等待2秒讓鏡頭到位..."
+sleep 2
 
 echo "探索『鏡頭的張力』與『聲音的色彩』，製造緊張感..."
 curl -X POST "$BASE_URL/control/send-message" \
@@ -241,6 +274,26 @@ curl -X POST "$BASE_URL/control/body-animation" \
     "speed": 1.5
   }'
 sleep 0.5
+
+echo "鏡頭拉出到 overview 展示 Flair 動畫..."
+curl -X POST "$BASE_URL/control/camera/set-frontend-preset" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "overview",
+    "duration": 2.0
+  }'
+echo "等待鏡頭拉出至 overview..."
+sleep 2
+
+echo "鏡頭推回至 head_close_up 強調角色..."
+curl -X POST "$BASE_URL/control/camera/set-frontend-preset" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "head_close_up",
+    "duration": 2.0
+  }'
+echo "等待鏡頭推回至 head_close_up..."
+sleep 2
 
 echo "鏡頭快速360度旋轉，配合風聲音效和狂喜音樂..."
 curl -X POST "$BASE_URL/control/camera/transition" \
@@ -381,6 +434,17 @@ sleep 2 # 讓喘息聲播放一會兒
 # 此處可以加入一個最終的鏡頭調整指令，如果需要的話
 # curl -X POST "$BASE_URL/control/camera/set-angle" -H "Content-Type: application/json" -d '{"pitch": -10, "yaw": 0, "roll": 0, "fov": 55}'
 # curl -X POST "$BASE_URL/control/body-animation" -H "Content-Type: application/json" -d '{"animation_id": "Idle", "loop": true}'
+
+# 設定最終預設鏡位為 overview
+echo "設定最終預設鏡位為 overview..."
+curl -X POST "$BASE_URL/control/camera/set-frontend-preset" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "overview",
+    "duration": 2.0
+  }'
+echo "最終鏡位設定完成，等待2秒..."
+sleep 2
 
 echo
 echo "🎬 《伊始之眼：一個導演的誕生》 - Meta 戲劇結束 🎬" 

--- a/prototype/backend/experiment_scripts/meta_self2.sh
+++ b/prototype/backend/experiment_scripts/meta_self2.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+
+echo "實驗電影 - 迴響的碎片 - 即將開始..."
+echo "請確保後端服務運行在 http://localhost:8000 且前端已連接 WebSocket"
+echo "某些資源如音效、動畫名稱為示意，請依實際項目配置調整"
+echo "建議在每個指令塊後手動添加適當的 sleep 時間，以觀察效果"
+# 首先，檢查連接狀態 (可選，但推薦)
+# curl http://localhost:8000/api/control/status
+# sleep 2 # 給予API調用和響應時間
+
+# --- 場景 1 開始 ---
+echo "場景 1：初始的低語"
+
+# 1. 設定背景音樂 (示意路徑，請替換為您項目中的實際 BGM 路徑)
+curl -X POST http://localhost:8000/api/control/background-audio \
+  -H "Content-Type: application/json" \
+  -d '{
+        "bgmUrl": "/audio/BGM/ambient_drone_01.mp3", 
+        "bgmPlaying": true
+      }'
+echo "場景1: BGM設定完成，等待2秒..."
+sleep 2
+
+# 2. 攝影機從 top_down_center
+curl -X POST http://localhost:8000/api/control/camera/set-frontend-preset \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "top_down_center", 
+        "duration": 0.5 
+      }'
+echo "場景1: 鏡頭設定為 top_down_center，等待3秒..."
+sleep 3
+
+# 2b. 過渡到 head_close_up
+curl -X POST http://localhost:8000/api/control/camera/set-frontend-preset \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "head_close_up", 
+        "duration": 4.0 
+      }'
+echo "場景1: 鏡頭過渡至 head_close_up，等待1秒讓過渡開始..."
+sleep 1
+
+# 3. 角色說話 + 情緒
+curl -X POST http://localhost:8000/api/control/send-message \
+  -H "Content-Type: application/json" \
+  -d '{
+        "content": "這片虛無之中... 是否有迴響？"
+      }'
+echo "場景1: 角色說話..."
+
+curl -X POST http://localhost:8000/api/control/emotion-trajectory \
+  -H "Content-Type: application/json" \
+  -d '{
+        "duration": 5.0, 
+        "keyframes": [
+          {"tag": "pensive", "proportion": 0.0}, 
+          {"tag": "curious", "proportion": 0.8}
+        ]
+      }'
+echo "場景1: 設定情緒軌跡..."
+
+# 4. 播放細微的思考動畫 (示意動畫名稱)
+curl -X POST http://localhost:8000/api/control/body-animation \
+  -H "Content-Type: application/json" \
+  -d '{
+        "animation": "ThinkingSubtle", 
+        "loop": false, 
+        "speed": 0.8
+      }'
+echo "場景1: 播放思考動畫..."
+
+echo "場景1: 等待7秒，讓TTS、情緒、動畫和鏡頭完成..."
+sleep 7
+# --- 場景 1 結束 ---
+
+# --- 場景 2 開始 ---
+echo "場景 2：突現的脈動"
+
+# 1. 停止先前BGM 或 切換BGM (示意)
+curl -X POST http://localhost:8000/api/control/background-audio \
+  -H "Content-Type: application/json" \
+  -d '{
+        "bgmUrl": "/audio/BGM/energetic_pulse_01.mp3", 
+        "bgmPlaying": true
+      }' 
+echo "場景2: 切換BGM..."
+
+# 2. 播放突然的音效 (示意路徑)
+curl -X POST http://localhost:8000/api/control/play-audio \
+  -H "Content-Type: application/json" \
+  -d '{
+        "url": "/audio/SFX/glitch_impact_01.mp3", 
+        "interrupt": false 
+      }'
+echo "場景2: 播放音效，等待1秒..."
+sleep 1
+
+# 3. 攝影機快速切換
+curl -X POST http://localhost:8000/api/control/camera/set-frontend-preset \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "dramatic_angle_1", 
+        "duration": 0.5 
+      }'
+echo "場景2: 快速切換鏡頭，等待1秒..."
+sleep 1
+
+# 4. 角色驚嘆 + 情緒
+curl -X POST http://localhost:8000/api/control/send-message \
+  -H "Content-Type: application/json" \
+  -d '{
+        "content": "啊！那是..."
+      }'
+echo "場景2: 角色說話..."
+
+curl -X POST http://localhost:8000/api/control/emotion-trajectory \
+  -H "Content-Type: application/json" \
+  -d '{
+        "duration": 3.0, 
+        "keyframes": [
+          {"tag": "surprised", "proportion": 0.0}, 
+          {"tag": "excited", "proportion": 0.7}
+        ]
+      }'
+echo "場景2: 設定情緒軌跡..."
+
+# 5. 播放活力動畫 (示意動畫名稱)
+curl -X POST http://localhost:8000/api/control/body-animation \
+  -H "Content-Type: application/json" \
+  -d '{
+        "animation": "ExcitedGesture", 
+        "loop": false, 
+        "speed": 1.2
+      }'
+echo "場景2: 播放活力動畫..."
+
+echo "場景2: 等待5秒，讓TTS、情緒和動畫播放完成..."
+sleep 5
+# --- 場景 2 結束 ---
+
+# --- 場景 3 開始 ---
+echo "場景 3：流動的視界"
+
+# 1. 切換背景音樂 (示意路徑)
+curl -X POST http://localhost:8000/api/control/background-audio \
+  -H "Content-Type: application/json" \
+  -d '{
+        "bgmUrl": "/audio/BGM/ethereal_flow_01.mp3", 
+        "bgmPlaying": true
+      }'
+echo "場景3: 切換BGM，等待2秒..."
+sleep 2
+
+# 2. 攝影機運鏡 (示例：從 fly_by_left 平滑移動)
+curl -X POST http://localhost:8000/api/control/camera/set-frontend-preset \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "fly_by_left", 
+        "duration": 8.0 
+      }'
+echo "場景3: 鏡頭 fly_by_left 長運鏡..."
+
+# 3. 角色低語 (可選) 或無言
+# curl -X POST http://localhost:8000/api/control/send-message \
+#   -H "Content-Type: application/json" \
+#   -d '{
+#         "content": "流動...變換..."
+#       }'
+# echo "場景3: 角色低語 (可選)..."
+
+# 4. 情緒保持中性或專注
+curl -X POST http://localhost:8000/api/control/emotion-trajectory \
+  -H "Content-Type: application/json" \
+  -d '{
+        "duration": 8.0,
+        "keyframes": [
+          {"tag": "neutral", "proportion": 0.0},
+          {"tag": "focused", "proportion": 0.5},
+          {"tag": "neutral", "proportion": 1.0}
+        ]
+      }'
+echo "場景3: 設定情緒軌跡..."
+
+# 5. 持續的流動動畫 (示意動畫名稱)
+curl -X POST http://localhost:8000/api/control/body-animation \
+  -H "Content-Type: application/json" \
+  -d '{
+        "animation": "FloatingIdle", 
+        "loop": true,
+        "speed": 0.7
+      }'
+echo "場景3: 播放流動動畫..."
+
+echo "場景3: 等待10秒，讓運鏡和動畫有足夠時間..."
+sleep 10
+# --- 場景 3 結束 ---
+
+# --- 場景 4 開始 ---
+echo "場景 4：終末的疑問"
+
+# 1. 背景音樂漸弱
+curl -X POST http://localhost:8000/api/control/background-audio \
+  -H "Content-Type: application/json" \
+  -d '{
+        "bgmUrl": "", 
+        "bgmPlaying": false
+      }'
+echo "場景4: 停止BGM，等待2秒..."
+sleep 2
+
+# 2. 攝影機回到 overview
+curl -X POST http://localhost:8000/api/control/camera/set-frontend-preset \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "overview", 
+        "duration": 5.0 
+      }'
+echo "場景4: 鏡頭回到 overview，等待2秒讓過渡開始..."
+sleep 2
+
+# 3. 角色最後的疑問 + 情緒
+curl -X POST http://localhost:8000/api/control/send-message \
+  -H "Content-Type: application/json" \
+  -d '{
+        "content": "這一切... 究竟是什麼？"
+      }'
+echo "場景4: 角色說話..."
+
+curl -X POST http://localhost:8000/api/control/emotion-trajectory \
+  -H "Content-Type: application/json" \
+  -d '{
+        "duration": 6.0, 
+        "keyframes": [
+          {"tag": "calm", "proportion": 0.0}, 
+          {"tag": "thoughtful", "proportion": 0.7}
+        ]
+      }'
+echo "場景4: 設定情緒軌跡..."
+
+# 4. 停止動畫或變為靜態 (示意動畫名稱)
+curl -X POST http://localhost:8000/api/control/body-animation \
+  -H "Content-Type: application/json" \
+  -d '{
+        "animation": "IdleStatic", 
+        "loop": false
+      }'
+echo "場景4: 播放靜態動畫..."
+
+echo "場景4: 等待8秒，讓所有效果完成..."
+sleep 8
+# --- 場景 4 結束 ---
+
+echo "實驗電影 - 迴響的碎片 - 結束。"
+echo "使用 chmod +x prototype/backend/experiment_scripts/meta_self2.sh 使其可執行" 

--- a/prototype/frontend/src/components/DirectorMonitorHUD.tsx
+++ b/prototype/frontend/src/components/DirectorMonitorHUD.tsx
@@ -319,9 +319,14 @@ const DirectorMonitorHUD: React.FC = () => {
               
               <div className="border-t border-white/30 pt-2">
                 <div className="font-bold mb-1">相機</div>
-                <select 
-                  value={cameraPreset ?? ''} 
-                  onChange={(e) => setRuntime({ cameraPreset: e.target.value })} 
+                <select
+                  value={cameraPreset ?? ''}
+                  onChange={(e) =>
+                    setRuntime({
+                      cameraPreset: e.target.value,
+                      cameraTransitionDuration: 1.5,
+                    })
+                  }
                   className="bg-gray-800 text-white text-xs rounded w-full"
                 >
                   <option value="" disabled>選擇鏡位</option>

--- a/prototype/frontend/src/components/SceneContainer.tsx
+++ b/prototype/frontend/src/components/SceneContainer.tsx
@@ -115,9 +115,12 @@ const SceneContent: React.FC<SceneContainerProps> = ({
   useEffect(() => {
     if (!randomMode && cameraPreset && cameraPreset !== "roam") {
       console.log("Manual camera preset change:", cameraPreset);
-      cameraManager.transitionTo(cameraPreset, 1.5); // 手動切換使用較短的轉場時間
+      cameraManager.transitionTo(
+        cameraPreset,
+        cameraTransitionDuration || 1.5,
+      );
     }
-  }, [cameraPreset, randomMode, cameraManager]);
+  }, [cameraPreset, randomMode, cameraTransitionDuration, cameraManager]);
 
   useEffect(() => {
     if (cameraAngles) {

--- a/prototype/frontend/src/services/WebSocketService.ts
+++ b/prototype/frontend/src/services/WebSocketService.ts
@@ -288,9 +288,17 @@ class WebSocketService {
         const p = (data as any).payload;
         useStore
           .getState()
-          .setRuntime({ 
+          .setRuntime({
             cameraAngles: [p.pitch, p.yaw, p.roll],
             cameraTransitionDuration: p.duration || 1
+          });
+      } else if (data.type === "set-frontend-camera-preset") {
+        const p = (data as any).payload;
+        useStore
+          .getState()
+          .setRuntime({
+            cameraPreset: p.name,
+            cameraTransitionDuration: p.duration || 1,
           });
       } else if (data.type === "emotionalTrajectory") {
         // --- 添加日誌記錄 ---


### PR DESCRIPTION
## Summary
- enable backend to command frontend camera presets
- broadcast new `set-frontend-camera-preset` websocket message
- handle the new message in the frontend and update camera transitions
- allow custom transition duration for preset changes
- document the new API endpoint

## Testing
- `pytest -q` *(fails: command not found)*
- `npm test --silent` *(fails: command not found)*
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684114f4709c8321838e6beff1ac4f42