### PR TITLE
Fix random audio loops

### DIFF
--- a/prototype/frontend/src/services/WebSocketService.ts
+++ b/prototype/frontend/src/services/WebSocketService.ts
@@ -237,8 +237,9 @@ class WebSocketService {
     try {
       const data = JSON.parse(event.data) as WebSocketMessage;
       if (data.type === "director-state") {
-        directorBus.emit("stateUpdate", (data as DirectorStateMessage).payload);
-        useStore.getState().setRuntime((data as DirectorStateMessage).payload);
+        const payload = (data as DirectorStateMessage).payload;
+        directorBus.emit("stateUpdate", payload);
+        useStore.getState().setRuntime(payload, { silent: true });
         return;
       }
       if (data.type === "audio-control") {
@@ -246,13 +247,13 @@ class WebSocketService {
         if (payload.bgmUrl) {
           useStore
             .getState()
-            .setRuntime({ bgm: payload.bgmUrl, bgmPlaying: true });
+            .setRuntime({ bgm: payload.bgmUrl, bgmPlaying: true }, { silent: true });
         }
         if (payload.bgmPlaying !== undefined) {
-          useStore.getState().setRuntime({ bgmPlaying: payload.bgmPlaying });
+          useStore.getState().setRuntime({ bgmPlaying: payload.bgmPlaying }, { silent: true });
         }
         if (payload.sfxUrl) {
-          useStore.getState().setRuntime({ selectedEffect: payload.sfxUrl });
+          useStore.getState().setRuntime({ selectedEffect: payload.sfxUrl }, { silent: true });
         }
         return;
       }

--- a/prototype/frontend/src/store/slices/runtimeSlice.ts
+++ b/prototype/frontend/src/store/slices/runtimeSlice.ts
@@ -32,8 +32,15 @@ export interface RuntimeSlice {
   videoDuration: number;
   videoPlaybackRate: number;
   videoScreens: VideoScreen[];
-  setVideoScreen: (id: string, partial: Partial<VideoScreen>) => void;
-  setRuntime: (partial: Partial<RuntimeSlice>) => void;
+  setVideoScreen: (
+    id: string,
+    partial: Partial<VideoScreen>,
+    options?: { silent?: boolean },
+  ) => void;
+  setRuntime: (
+    partial: Partial<RuntimeSlice>,
+    options?: { silent?: boolean },
+  ) => void;
 }
 
 export const createRuntimeSlice: StateCreator<RuntimeSlice> = (set) => ({
@@ -46,7 +53,7 @@ export const createRuntimeSlice: StateCreator<RuntimeSlice> = (set) => ({
   cameraPreset: null,
   cameraAngles: null,
   cameraTransitionDuration: 1,
-  randomMode: true,
+  randomMode: false,
   fps: 0,
   cpu: 0,
   videoPlaying: false,
@@ -86,16 +93,20 @@ export const createRuntimeSlice: StateCreator<RuntimeSlice> = (set) => ({
       playbackRate: 1,
     },
   ],
-  setVideoScreen: (id, partial) =>
+  setVideoScreen: (id, partial, options?: { silent?: boolean }) =>
     set((state) => {
       const screens = state.videoScreens.map((s) =>
         s.id === id ? { ...s, ...partial } : s,
       );
-      directorBus.emit("stateUpdate", { videoScreens: screens });
+      if (!options?.silent) {
+        directorBus.emit("stateUpdate", { videoScreens: screens });
+      }
       return { videoScreens: screens };
     }),
-  setRuntime: (partial) => {
-    directorBus.emit("stateUpdate", partial as Partial<DirectorState>);
+  setRuntime: (partial, options?: { silent?: boolean }) => {
+    if (!options?.silent) {
+      directorBus.emit("stateUpdate", partial as Partial<DirectorState>);
+    }
     set(partial);
   },
 });


### PR DESCRIPTION
## Summary
- disable `randomMode` by default
- add optional `silent` flag to `setRuntime` and `setVideoScreen`
- avoid sending state echoes back over websocket

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest`
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841590b7a848321861252f97cf9a249