### PR TITLE
Fix persistent red overlay on video

### DIFF
--- a/prototype/frontend/src/components/VideoPlayer.tsx
+++ b/prototype/frontend/src/components/VideoPlayer.tsx
@@ -110,6 +110,9 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       console.log('VideoPlayer: No playlist or empty playlist');
       return;
     }
+
+    // Reset overlay state whenever a new video loads
+    setAutoplayFailed(false);
     
     console.log(`VideoPlayer ${screenId}: Loading video`, playlist[index]);
     
@@ -152,6 +155,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       video.play().then(() => {
         console.log(`VideoPlayer ${screenId}: Video started playing`);
         setVideoScreen(screenId, { playing: true });
+        setAutoplayFailed(false);
       }).catch((error) => {
         console.log(`VideoPlayer ${screenId}: Autoplay failed`, error);
         setAutoplayFailed(true);
@@ -175,6 +179,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     const onPlay = () => {
       console.log(`VideoPlayer ${screenId}: Video play event`);
       setVideoScreen(screenId, { playing: true });
+      setAutoplayFailed(false);
     };
 
     const onPause = () => {


### PR DESCRIPTION
## Summary
- reset `autoplayFailed` when video loads
- clear overlay state whenever playback starts

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest` *(passes: no tests found)*
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68415f932c4483218ccf49426061f4b1