### PR TITLE
Add head size and scene control endpoints

### DIFF
--- a/docs/backend/head_and_scene_control_api.md
+++ b/docs/backend/head_and_scene_control_api.md
@@ -1,0 +1,33 @@
+# Head Size & Scene Control API
+
+提供控制頭部模型縮放與房間場景顯示的後端端點，方便前端在運行時調整虛擬環境。
+
+## 端點一覽
+
+| 方法 | 路徑 | 說明 |
+|------|------|------|
+|`POST`|`/api/control/head-size`|調整前端頭部模型的縮放比|
+|`POST`|`/api/control/scene-display`|切換或顯示/隱藏指定場景|
+
+### `/api/control/head-size`
+
+- `scaleFactor`：`0.1` 至 `5.0` 的數值，表示模型縮放倍數。
+
+```bash
+curl -X POST http://localhost:8000/api/control/head-size \
+  -H 'Content-Type: application/json' \
+  -d '{"scaleFactor": 1.5}'
+```
+
+### `/api/control/scene-display`
+
+- `displayScene`：布林值，是否顯示房間場景。
+- `sceneName`：可選，指定要載入的場景 ID（如 `room-a` 或 `room-b`）。
+
+```bash
+curl -X POST http://localhost:8000/api/control/scene-display \
+  -H 'Content-Type: application/json' \
+  -d '{"displayScene": true, "sceneName": "room-a"}'
+```
+
+無效縮放值將回傳 `400 Bad Request`，未知場景名稱則回傳 `404 Not Found`。

--- a/integration_tests/scene_control/test_head_scene_endpoints.py
+++ b/integration_tests/scene_control/test_head_scene_endpoints.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Integration tests for head-size and scene-display endpoints."""
+
+import asyncio
+import json
+import time
+from typing import Any, Dict
+
+import requests
+import websockets
+
+API_BASE = "http://localhost:8000"
+WS_URL = "ws://localhost:8000/ws"
+
+
+async def wait_for_type(
+    ws: websockets.WebSocketClientProtocol, expected: str, timeout: float = 5.0
+) -> Dict[str, Any] | None:
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            msg = await asyncio.wait_for(
+                ws.recv(), timeout=timeout - (time.time() - start)
+            )
+            data = json.loads(msg)
+            if data.get("type") == expected:
+                return data
+        except asyncio.TimeoutError:
+            pass
+    return None
+
+
+async def main() -> None:
+    async with websockets.connect(WS_URL) as ws:
+        print("🚀 Testing head-size valid value")
+        resp = requests.post(
+            f"{API_BASE}/api/control/head-size", json={"scaleFactor": 1.5}
+        )
+        assert resp.status_code == 200, f"Unexpected status {resp.status_code}"
+        data = await wait_for_type(ws, "head-size")
+        assert data and data.get("scaleFactor") == 1.5, "WebSocket head-size mismatch"
+        print("✅ head-size:", data)
+
+        print("🚀 Testing head-size invalid negative")
+        resp = requests.post(
+            f"{API_BASE}/api/control/head-size", json={"scaleFactor": -1}
+        )
+        assert resp.status_code == 400, "Expected 400 for invalid scale"
+        print("✅ invalid head-size rejected")
+
+        print("🚀 Testing scene-display with valid scene")
+        resp = requests.post(
+            f"{API_BASE}/api/control/scene-display",
+            json={"displayScene": True, "sceneName": "room-a"},
+        )
+        assert resp.status_code == 200, f"Unexpected status {resp.status_code}"
+        data = await wait_for_type(ws, "scene-display")
+        assert data and data.get("payload", {}).get("sceneName") == "room-a"
+        print("✅ scene-display:", data)
+
+        print("🚀 Testing scene-display invalid scene")
+        resp = requests.post(
+            f"{API_BASE}/api/control/scene-display",
+            json={"displayScene": True, "sceneName": "nope"},
+        )
+        assert resp.status_code == 404, "Expected 404 for bad scene name"
+        print("✅ invalid scene rejected")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/prototype/backend/api/endpoints/control.py
+++ b/prototype/backend/api/endpoints/control.py
@@ -7,13 +7,12 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-
 from services.camera_control import CameraControlService
 
 from ..endpoints.websocket import manager, murmur_service
-from ..endpoints.websocket import (
-    save_audio_and_set_url as save_websocket_audio,
-)  # 導入 WebSocket 連接管理器和 MurmurService
+from ..endpoints.websocket import \
+    save_audio_and_set_url as \
+    save_websocket_audio  # 導入 WebSocket 連接管理器和 MurmurService
 from ..endpoints.websocket import tts_service
 
 # 設置日誌
@@ -238,7 +237,7 @@ async def background_audio_control(request: BackgroundAudioRequest):
             raise HTTPException(status_code=503, detail="沒有活動的前端連接")
 
         audio_data: Dict[str, Any] = {"type": "audio-control"}
-        
+
         # 處理 BGM URL（包含空字串停止功能）
         if request.bgmUrl is not None:  # 使用 is not None 來包含空字串
             audio_data["bgmUrl"] = request.bgmUrl
@@ -247,11 +246,11 @@ async def background_audio_control(request: BackgroundAudioRequest):
                 audio_data["bgmPlaying"] = False
             else:
                 audio_data["bgmPlaying"] = True
-        
+
         # 處理明確的播放/暫停控制
         if request.bgmPlaying is not None:
             audio_data["bgmPlaying"] = request.bgmPlaying
-            
+
         # 處理音效 URL
         if request.sfxUrl is not None:
             audio_data["sfxUrl"] = request.sfxUrl
@@ -413,4 +412,49 @@ async def control_body_animation(command: BodyAnimationCommand):
     message = {"type": "body-animation", "payload": payload}
     await manager.broadcast(json.dumps(message))
     logger.info(f"Broadcast body animation command: {payload}")
+    return {"success": True}
+
+
+# --- 新增：頭部大小與場景顯示控制 ---
+
+
+class HeadSizeRequest(BaseModel):
+    scaleFactor: float
+
+
+class SceneDisplayRequest(BaseModel):
+    displayScene: bool
+    sceneName: Optional[str] = None
+
+
+VALID_SCENES = {"room-a", "room-b"}
+
+
+@router.post("/control/head-size")
+async def set_head_size(request: HeadSizeRequest):
+    """Set the scale of the head model on the frontend."""
+    if not manager.active_connections:
+        raise HTTPException(status_code=503, detail="沒有活動的前端連接")
+    if request.scaleFactor <= 0 or request.scaleFactor > 5:
+        raise HTTPException(status_code=400, detail="Invalid scaleFactor")
+
+    message = {"type": "head-size", "scaleFactor": request.scaleFactor}
+    await manager.broadcast(json.dumps(message))
+    logger.info(f"Set head size: {request.scaleFactor}")
+    return {"success": True, "scaleFactor": request.scaleFactor}
+
+
+@router.post("/control/scene-display")
+async def control_scene_display(request: SceneDisplayRequest):
+    """Toggle or change the active 3D scene on the frontend."""
+    if not manager.active_connections:
+        raise HTTPException(status_code=503, detail="沒有活動的前端連接")
+
+    if request.sceneName and request.sceneName not in VALID_SCENES:
+        raise HTTPException(status_code=404, detail="Scene not found")
+
+    payload = {"displayScene": request.displayScene, "sceneName": request.sceneName}
+    message = {"type": "scene-display", "payload": payload}
+    await manager.broadcast(json.dumps(message))
+    logger.info(f"Scene display control: {payload}")
     return {"success": True}


### PR DESCRIPTION
## Summary
- implement `/api/control/head-size` and `/api/control/scene-display`
- document the new control APIs
- add integration tests for the new endpoints

## Testing
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: 403 Forbidden)*
- `pytest -q` *(no tests ran)*
- `npm test --silent` *(fails: react-scripts not found)*
- `mypy prototype/backend` *(fails: songs_config module mapped twice)*

------
https://chatgpt.com/codex/tasks/task_e_6843fc282b5883219af90beb89052ba2