### PR TITLE
Add Gemini image generation endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ Audio_Temp/
 prototype/frontend/public/videos/
 prototype/frontend/public/scenes
 prototype/backend/api/audio
+prototype/backend/generated_images

--- a/docs/backend/cursor_api_control_response_guidelines.md
+++ b/docs/backend/cursor_api_control_response_guidelines.md
@@ -225,7 +225,11 @@ To help Cursor better understand and utilize project assets, here are some key p
 **11. Image Generation (`/api/generate-image`)**
 ```json
 {
-  "description": "string (Text description of the image to generate, required. Can be in Chinese or English. Examples: '一隻可愛的橘貓在花園裡', 'a beautiful sunset over mountains')"
+  "description": "string (Text description of the image to generate, required. Can be in Chinese or English. Examples: '一隻可愛的橘貓在花園裡', 'a beautiful sunset over mountains')",
+  "position": "string (Optional, position preset: 'center-right'(default), 'center-left', 'top-right', 'top-left', 'bottom-right', 'bottom-left', 'center')",
+  "size": "string (Optional, size preset: 'small', 'medium'(default), 'large')",
+  "custom_position": "object (Optional, custom CSS position properties, overrides 'position'. Example: {'top': '50%', 'right': '50px', 'transform': 'translateY(-50%)'})",
+  "custom_size": "object (Optional, custom CSS size properties, overrides 'size'. Example: {'width': '400px', 'height': '300px'})"
 }
 ```
 
@@ -234,9 +238,24 @@ To help Cursor better understand and utilize project assets, here are some key p
 {
   "success": "boolean (true if generation succeeded)",
   "url": "string (Relative URL path to the generated image, e.g., '/generated-images/image_1234567890.png')",
-  "caption": "string (AI-generated description of the image, may be in Chinese or English)"
+  "caption": "string (AI-generated description of the image, may be in Chinese or English)",
+  "display_config": "object (Configuration for frontend display positioning and sizing)"
 }
 ```
+
+**Position Presets:**
+- `center-right` (default): Middle right, vertically centered
+- `center-left`: Middle left, vertically centered  
+- `top-right`: Top right corner
+- `top-left`: Top left corner
+- `bottom-right`: Bottom right corner
+- `bottom-left`: Bottom left corner
+- `center`: Absolute center of screen
+
+**Size Presets:**
+- `small`: 250px × 200px
+- `medium` (default): 350px × 280px
+- `large`: 450px × 360px
 
 **Generated Images Access:**
 - Generated images are automatically saved to `prototype/backend/generated_images/` directory
@@ -480,28 +499,47 @@ curl -X POST http://localhost:8000/api/control/head-size \
 
 **Example 9: AI Image Generation**
 ```bash
-# Generate a simple image (Chinese description)
+# Basic image generation (default: center-right, medium)
 curl -X POST http://localhost:8000/api/generate-image \
   -H "Content-Type: application/json" \
   -d '{"description": "一隻可愛的橘貓在花園裡玩耍"}'
 
-# Generate a space-themed image (English description)
+# Position control - left side, large size
 curl -X POST http://localhost:8000/api/generate-image \
   -H "Content-Type: application/json" \
-  -d '{"description": "astronaut floating in space with beautiful nebula background"}'
+  -d '{"description": "台灣辣妹在太空夜市吃小籠包", "position": "center-left", "size": "large"}'
 
-# Generate a Taiwan influencer style image
+# Position control - top corner, small size
 curl -X POST http://localhost:8000/api/generate-image \
   -H "Content-Type: application/json" \
-  -d '{"description": "台灣辣妹網紅在太空站內自拍直播，穿著粉色太空服，做出比愛心手勢"}'
+  -d '{"description": "迷你太空機器人修理衛星", "position": "top-right", "size": "small"}'
 
-# Generate artistic scene
+# Center large image for dramatic effect
 curl -X POST http://localhost:8000/api/generate-image \
   -H "Content-Type: application/json" \
-  -d '{"description": "futuristic space city with neon lights and flying cars at sunset"}'
+  -d '{"description": "銀河中央的太空女王跳舞", "position": "center", "size": "large"}'
+
+# Custom positioning and sizing
+curl -X POST http://localhost:8000/api/generate-image \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "太空花園裡的蝴蝶仙子",
+    "custom_position": {"bottom": "30px", "left": "30px"},
+    "custom_size": {"width": "300px", "height": "400px"}
+  }'
+
+# Multiple position presets available:
+# - center-right (default): Middle right, vertically centered
+# - center-left: Middle left, vertically centered
+# - top-right, top-left: Corner positions
+# - bottom-right, bottom-left: Bottom corner positions  
+# - center: Absolute center (dramatic effect)
+
+# Size presets: small (250x200), medium (350x280), large (450x360)
+# Custom sizes and positions override presets
 
 # Note: Generated images will automatically appear in the frontend ImageOverlay
-# and are accessible at the returned URL path (e.g., /generated-images/image_xxx.png)
+# with the specified position, size, and appropriate entrance animation
 ```
 
 ## 🎬 Director's Cut: The Art of the 3-Command Combo (導演進階：三連擊的藝術)
@@ -637,6 +675,10 @@ sleep 5
     6.  **Image File Access?** Verify that generated images are accessible at `http://localhost:8000/generated-images/`.
     7.  **WebSocket Connection?** Images are broadcast via WebSocket, ensure frontend is connected.
     8.  **Static File Serving?** Confirm `/generated-images/` static route is mounted in backend `__init__.py`.
+    9.  **Position/Size Not Working?** Check `display_config` in WebSocket message and frontend style application.
+    10. **Invalid Position/Size Values?** Ensure position presets match: 'center-right', 'center-left', 'top-right', 'top-left', 'bottom-right', 'bottom-left', 'center'. Size presets: 'small', 'medium', 'large'.
+    11. **Custom CSS Not Applied?** Verify `custom_position` and `custom_size` objects contain valid CSS properties.
+    12. **Animation Issues?** Check frontend CSS classes for proper animation based on position (left/right/center).
 
 ## ✅ Response Validation Guide
 
@@ -677,4 +719,8 @@ sleep 5
 -   Storage location: `prototype/backend/generated_images/`
 -   Accessible via: `http://localhost:8000/generated-images/{filename}`
 -   Frontend display: Automatically shown in `ImageOverlay` component for 10 seconds
--   WebSocket broadcast: Images are broadcasted with type `generated-image` including URL and caption
+-   WebSocket broadcast: Images are broadcasted with type `generated-image` including URL, caption, and display_config
+-   Position control: 7 preset positions (center-right default) plus custom positioning
+-   Size control: 3 preset sizes (medium default) plus custom sizing
+-   Animation support: Different entrance animations based on position (slide from right/left, fade for center)
+-   Display config: Backend controls frontend positioning via `display_config` object in WebSocket message

--- a/docs/backend/cursor_api_control_response_guidelines.md
+++ b/docs/backend/cursor_api_control_response_guidelines.md
@@ -11,6 +11,7 @@ APIs are defined in `prototype/backend/api/endpoints/`:
 - `speech.py` – speech to text processing.
 - `health.py` – service health check.
 - `websocket.py` – real-time communication endpoint.
+- `image_generation.py` – AI image generation using Gemini models.
 
 The application registers these routes in `prototype/backend/api/__init__.py`.
 
@@ -50,6 +51,11 @@ The request models for these routes are defined at the top of `control.py` and i
 |`POST`|`/api/speech-to-text`|Upload an audio file and receive transcribed text plus a generated reply.|
 |`POST`|`/api/speech-to-text/base64`|Convert base64-encoded audio to text and optional reply.|
 
+### Image Generation Endpoints
+| Method | Path | Description |
+|-------|------|-------------|
+|`POST`|`/api/generate-image`|Generate an AI image using Gemini 2.0 Flash Preview Image Generation model and broadcast via WebSocket.|
+
 ### System Endpoint
 | Method | Path | Description |
 |-------|------|-------------|
@@ -62,8 +68,9 @@ A websocket endpoint at `/ws` provides real-time conversation handling. It manag
 1. **Direct control commands** – map explicit directives such as "play this audio", "set camera angle", or "switch to overview camera" to the corresponding control endpoint (e.g., `/api/control/camera/set-frontend-preset` for named camera views).
 2. **Monitor operations** – interpret requests about changing monitor visibility, content or volume and call the monitor endpoints.
 3. **Speech processing** – when users supply audio to convert or ask for generated speech, use the speech endpoints.
-4. **Status queries** – requests for availability or connection information should call `/api/control/status` or `/api/health`.
-5. **Unstructured chat** – route open conversation through the websocket endpoint.
+4. **Image generation requests** – when users ask for image generation or want to create visual content, use the `/api/generate-image` endpoint.
+5. **Status queries** – requests for availability or connection information should call `/api/control/status` or `/api/health`.
+6. **Unstructured chat** – route open conversation through the websocket endpoint.
 
 ## Response Generation
 When an API call succeeds, include key fields from the returned JSON in natural language. For example, a successful `send-message` call should note the connection count. If an error occurs, return a concise summary of the failure and its HTTP status.
@@ -214,6 +221,28 @@ To help Cursor better understand and utilize project assets, here are some key p
   "scale": "array (Optional, room scale [x, y, z] or [uniform] for equal scaling, must be positive)"
 }
 ```
+
+**11. Image Generation (`/api/generate-image`)**
+```json
+{
+  "description": "string (Text description of the image to generate, required. Can be in Chinese or English. Examples: '一隻可愛的橘貓在花園裡', 'a beautiful sunset over mountains')"
+}
+```
+
+**Image Generation Response:**
+```json
+{
+  "success": "boolean (true if generation succeeded)",
+  "url": "string (Relative URL path to the generated image, e.g., '/generated-images/image_1234567890.png')",
+  "caption": "string (AI-generated description of the image, may be in Chinese or English)"
+}
+```
+
+**Generated Images Access:**
+- Generated images are automatically saved to `prototype/backend/generated_images/` directory
+- Images are accessible via HTTP at `http://localhost:8000{url}` (e.g., `http://localhost:8000/generated-images/image_1234567890.png`)
+- Images are automatically broadcasted via WebSocket to connected frontends with message type `generated-image`
+- Frontend `ImageOverlay` component will display generated images for 10 seconds automatically
 
 ## 🎉 Best Practices for a Smooth Show! 🎉
 
@@ -449,6 +478,32 @@ curl -X POST http://localhost:8000/api/control/head-size \
   -d '{"scaleFactor": 1.0}'
 ```
 
+**Example 9: AI Image Generation**
+```bash
+# Generate a simple image (Chinese description)
+curl -X POST http://localhost:8000/api/generate-image \
+  -H "Content-Type: application/json" \
+  -d '{"description": "一隻可愛的橘貓在花園裡玩耍"}'
+
+# Generate a space-themed image (English description)
+curl -X POST http://localhost:8000/api/generate-image \
+  -H "Content-Type: application/json" \
+  -d '{"description": "astronaut floating in space with beautiful nebula background"}'
+
+# Generate a Taiwan influencer style image
+curl -X POST http://localhost:8000/api/generate-image \
+  -H "Content-Type: application/json" \
+  -d '{"description": "台灣辣妹網紅在太空站內自拍直播，穿著粉色太空服，做出比愛心手勢"}'
+
+# Generate artistic scene
+curl -X POST http://localhost:8000/api/generate-image \
+  -H "Content-Type: application/json" \
+  -d '{"description": "futuristic space city with neon lights and flying cars at sunset"}'
+
+# Note: Generated images will automatically appear in the frontend ImageOverlay
+# and are accessible at the returned URL path (e.g., /generated-images/image_xxx.png)
+```
+
 ## 🎬 Director's Cut: The Art of the 3-Command Combo (導演進階：三連擊的藝術)
 
 While individual API calls are powerful, the true art of directing lies in weaving them into a seamless narrative. Since most API calls are **non-blocking** (they return `success` immediately, without waiting for the action to complete), crafting complex scenes requires a method to control timing and order.
@@ -573,6 +628,16 @@ sleep 5
     3.  **Frontend Support?** Ensure frontend has implemented scene switching functionality.
     4.  **`displayScene: true`?** Must be true to show any scene.
 
+-   **Image Generation Not Working?**
+    1.  **API Key Set?** Ensure `GOOGLE_API_KEY` is properly configured in backend environment.
+    2.  **Description Field?** The request must include a `description` field with text content.
+    3.  **Model Access?** Verify access to Gemini 2.0 Flash Preview Image Generation model.
+    4.  **Backend Logs?** Check for detailed error messages about image generation failures.
+    5.  **Frontend Not Showing Images?** Check if `ImageOverlay` component is properly mounted in `App.tsx`.
+    6.  **Image File Access?** Verify that generated images are accessible at `http://localhost:8000/generated-images/`.
+    7.  **WebSocket Connection?** Images are broadcast via WebSocket, ensure frontend is connected.
+    8.  **Static File Serving?** Confirm `/generated-images/` static route is mounted in backend `__init__.py`.
+
 ## ✅ Response Validation Guide
 
 -   **Successful Calls Generally Return:** `{"success": true, ...}`. Specific endpoints might include additional data (e.g., `url` for `play-audio`, `connections` for `send-message`).
@@ -603,3 +668,13 @@ sleep 5
 -   `太空直播中.mp4`
 -   `太空瑜伽.mp4`
 -   `模擬星雲圖.mp4`
+
+### Generated Images (automatically created by AI - use `/generated-images/` prefix)
+-   Images are dynamically generated using Gemini 2.0 Flash Preview Image Generation
+-   File naming pattern: `image_{timestamp}.png` (e.g., `image_1749308094327.png`)
+-   Typical resolutions: 1024x684 pixels
+-   Format: PNG with RGB color space
+-   Storage location: `prototype/backend/generated_images/`
+-   Accessible via: `http://localhost:8000/generated-images/{filename}`
+-   Frontend display: Automatically shown in `ImageOverlay` component for 10 seconds
+-   WebSocket broadcast: Images are broadcasted with type `generated-image` including URL and caption

--- a/docs/backend/image_generation_api.md
+++ b/docs/backend/image_generation_api.md
@@ -1,0 +1,28 @@
+# Image Generation API
+
+利用 Gemini 模型產生圖像並透過 WebSocket 廣播結果。
+
+## 端點一覽
+
+| 方法 | 路徑 | 說明 |
+|------|------|------|
+|`POST`|`/api/generate-image`|根據描述產生圖像，回傳圖片 URL 並廣播|
+
+### 請求格式
+
+```json
+{
+  "description": "一段描述文字"
+}
+```
+
+### 回應範例
+
+```json
+{
+  "success": true,
+  "url": "/generated-images/image_1700000000000.png"
+}
+```
+
+產生的圖片會儲存在 `prototype/backend/generated_images/` 目錄，檔名以時間戳記為基礎。前端會收到 `generated-image` 類型的 WebSocket 訊息，內容包含圖片路徑。

--- a/integration_tests/image_generation/test_image_generation_api.py
+++ b/integration_tests/image_generation/test_image_generation_api.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Integration tests for the image generation endpoint."""
+
+import asyncio
+import json
+import os
+import time
+
+import requests
+import websockets
+
+API_BASE = "http://localhost:8000"
+ENDPOINT = f"{API_BASE}/api/generate-image"
+WS_URL = "ws://localhost:8000/ws"
+IMAGE_DIR = "prototype/backend/generated_images"
+
+
+def test_generate_image_api():
+    payload = {"description": "simple test pattern"}
+    response = requests.post(ENDPOINT, json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert "url" in data
+    filename = data["url"].split("/generated-images/")[-1]
+    assert os.path.exists(os.path.join(IMAGE_DIR, filename))
+
+
+async def test_websocket_notification():
+    async with websockets.connect(WS_URL) as ws:
+        requests.post(ENDPOINT, json={"description": "ws image"})
+        message = await asyncio.wait_for(ws.recv(), timeout=10)
+        data = json.loads(message)
+        assert data.get("type") == "generated-image"
+        assert "url" in data
+
+
+if __name__ == "__main__":
+    test_generate_image_api()
+    asyncio.run(test_websocket_notification())

--- a/prototype/backend/api/__init__.py
+++ b/prototype/backend/api/__init__.py
@@ -1,14 +1,16 @@
 import logging
 import os
 
-from admin import setup_admin
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import FileResponse
 
+from admin import setup_admin
+
 from .base import create_app
-from .endpoints import control, health, monitors, speech, websocket
+from .endpoints import (control, health, image_generation, monitors, speech,
+                        websocket)
 from .middleware.cors import setup_cors
 
 # 設置日誌
@@ -39,6 +41,7 @@ def init_app() -> FastAPI:
     app.include_router(health.router, prefix="/api", tags=["system"])
     app.include_router(control.router, prefix="/api", tags=["control"])
     app.include_router(monitors.router, prefix="/api", tags=["monitor"])
+    app.include_router(image_generation.router, prefix="/api", tags=["image"])
 
     # 創建音頻目錄（如果不存在）
     audio_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "audio")
@@ -47,6 +50,12 @@ def init_app() -> FastAPI:
     # 創建歌曲目錄（如果不存在）
     songs_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "songs")
     os.makedirs(songs_dir, exist_ok=True)
+
+    # Create image directory
+    images_dir = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "generated_images"
+    )
+    os.makedirs(images_dir, exist_ok=True)
 
     # 確保音頻目錄有正確的權限
     try:
@@ -68,6 +77,13 @@ def init_app() -> FastAPI:
         "/songs-assets",
         StaticFiles(directory=songs_dir, html=True, check_dir=True),
         name="songs",
+    )
+
+    # Mount generated images
+    app.mount(
+        "/generated-images",
+        StaticFiles(directory=images_dir, html=True, check_dir=True),
+        name="generated-images",
     )
 
     # 添加簡單的音頻文件訪問路由，作為備選方案

--- a/prototype/backend/api/endpoints/image_generation.py
+++ b/prototype/backend/api/endpoints/image_generation.py
@@ -4,6 +4,7 @@ import logging
 import os
 import time
 from io import BytesIO
+from typing import Optional
 
 from google import genai
 from google.genai.types import GenerateContentConfig
@@ -28,6 +29,14 @@ os.makedirs(GENERATED_DIR, exist_ok=True)
 
 class ImageGenerationRequest(BaseModel):
     description: str
+    # 位置控制 (可選)
+    position: Optional[str] = "center-right"  # center-right, top-right, bottom-right, center-left, top-left, bottom-left, center
+    # 大小控制 (可選)
+    size: Optional[str] = "medium"  # small, medium, large
+    # 自定義位置 (可選，優先於 position)
+    custom_position: Optional[dict] = None  # {"top": "50%", "right": "50px", "transform": "translateY(-50%)"}
+    # 自定義大小 (可選，優先於 size)
+    custom_size: Optional[dict] = None  # {"width": "350px", "height": "280px"}
 
 
 @router.post("/generate-image")
@@ -65,15 +74,57 @@ async def generate_image(request: ImageGenerationRequest):
         
         url = f"/generated-images/{filename}"
         
-        # 透過WebSocket廣播結果
+        # 處理位置和大小設定
+        display_config = _get_display_config(request)
+        
+        # 透過WebSocket廣播結果，包含顯示配置
         await manager.broadcast(json.dumps({
             "type": "generated-image", 
             "url": url,
-            "caption": caption
+            "caption": caption,
+            "display_config": display_config
         }))
         
-        return {"success": True, "url": url, "caption": caption}
+        return {
+            "success": True, 
+            "url": url, 
+            "caption": caption,
+            "display_config": display_config
+        }
         
     except Exception as e:
         logging.error(f"Image generation failed: {e}")
         raise HTTPException(status_code=500, detail="Image generation failed")
+
+
+def _get_display_config(request: ImageGenerationRequest) -> dict:
+    """根據請求參數生成顯示配置"""
+    config = {}
+    
+    # 處理位置
+    if request.custom_position:
+        config["position"] = request.custom_position
+    else:
+        position_presets = {
+            "center-right": {"top": "50%", "right": "50px", "transform": "translateY(-50%)"},
+            "top-right": {"top": "20px", "right": "20px"},
+            "bottom-right": {"bottom": "20px", "right": "20px"},
+            "center-left": {"top": "50%", "left": "50px", "transform": "translateY(-50%)"},
+            "top-left": {"top": "20px", "left": "20px"},
+            "bottom-left": {"bottom": "20px", "left": "20px"},
+            "center": {"top": "50%", "left": "50%", "transform": "translate(-50%, -50%)"}
+        }
+        config["position"] = position_presets.get(request.position, position_presets["center-right"])
+    
+    # 處理大小
+    if request.custom_size:
+        config["size"] = request.custom_size
+    else:
+        size_presets = {
+            "small": {"width": "250px", "height": "200px"},
+            "medium": {"width": "350px", "height": "280px"},
+            "large": {"width": "450px", "height": "360px"}
+        }
+        config["size"] = size_presets.get(request.size, size_presets["medium"])
+    
+    return config

--- a/prototype/backend/api/endpoints/image_generation.py
+++ b/prototype/backend/api/endpoints/image_generation.py
@@ -3,8 +3,10 @@ import json
 import logging
 import os
 import time
+from io import BytesIO
 
-import google.generativeai as genai
+from google import genai
+from google.genai.types import GenerateContentConfig
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
@@ -14,12 +16,12 @@ from .websocket import manager
 
 router = APIRouter()
 
-# Configure Gemini model
-genai.configure(api_key=settings.GOOGLE_API_KEY)
-model = genai.GenerativeModel("gemini-2.0-flash-preview-image-generation")
+# 使用新的Google Gen AI SDK配置客戶端
+client = genai.Client(api_key=settings.GOOGLE_API_KEY)
 
+# 修正路徑：從 api/endpoints 向上三層到達 backend 目錄
 GENERATED_DIR = os.path.join(
-    os.path.dirname(os.path.dirname(__file__)), "generated_images"
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "generated_images"
 )
 os.makedirs(GENERATED_DIR, exist_ok=True)
 
@@ -31,16 +33,47 @@ class ImageGenerationRequest(BaseModel):
 @router.post("/generate-image")
 async def generate_image(request: ImageGenerationRequest):
     try:
-        response = await model.generate_content_async(request.description)
-        part = response.candidates[0].content.parts[0]
-        image_bytes = base64.b64decode(part.inline_data.data)
+        # 使用正確的Gemini圖像生成模型和配置
+        response = client.models.generate_content(
+            model="gemini-2.0-flash-preview-image-generation",
+            contents=f"Generate an image of: {request.description}",
+            config=GenerateContentConfig(
+                response_modalities=["TEXT", "IMAGE"]
+            )
+        )
+        
+        # 解析回應
+        image_data = None
+        caption = ""
+        
+        for part in response.candidates[0].content.parts:
+            if part.text:
+                caption = part.text.strip()
+            elif part.inline_data:
+                image_data = part.inline_data.data
+        
+        if not image_data:
+            raise HTTPException(status_code=500, detail="No image generated")
+        
+        # 儲存圖像檔案
         filename = f"image_{int(time.time()*1000)}.png"
         file_path = os.path.join(GENERATED_DIR, filename)
+        
+        # 將圖像數據保存到檔案
         with open(file_path, "wb") as f:
-            f.write(image_bytes)
+            f.write(image_data)
+        
         url = f"/generated-images/{filename}"
-        await manager.broadcast(json.dumps({"type": "generated-image", "url": url}))
-        return {"success": True, "url": url}
+        
+        # 透過WebSocket廣播結果
+        await manager.broadcast(json.dumps({
+            "type": "generated-image", 
+            "url": url,
+            "caption": caption
+        }))
+        
+        return {"success": True, "url": url, "caption": caption}
+        
     except Exception as e:
         logging.error(f"Image generation failed: {e}")
         raise HTTPException(status_code=500, detail="Image generation failed")

--- a/prototype/backend/api/endpoints/image_generation.py
+++ b/prototype/backend/api/endpoints/image_generation.py
@@ -1,0 +1,46 @@
+import base64
+import json
+import logging
+import os
+import time
+
+import google.generativeai as genai
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from core.config import settings
+
+from .websocket import manager
+
+router = APIRouter()
+
+# Configure Gemini model
+genai.configure(api_key=settings.GOOGLE_API_KEY)
+model = genai.GenerativeModel("gemini-2.0-flash-preview-image-generation")
+
+GENERATED_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "generated_images"
+)
+os.makedirs(GENERATED_DIR, exist_ok=True)
+
+
+class ImageGenerationRequest(BaseModel):
+    description: str
+
+
+@router.post("/generate-image")
+async def generate_image(request: ImageGenerationRequest):
+    try:
+        response = await model.generate_content_async(request.description)
+        part = response.candidates[0].content.parts[0]
+        image_bytes = base64.b64decode(part.inline_data.data)
+        filename = f"image_{int(time.time()*1000)}.png"
+        file_path = os.path.join(GENERATED_DIR, filename)
+        with open(file_path, "wb") as f:
+            f.write(image_bytes)
+        url = f"/generated-images/{filename}"
+        await manager.broadcast(json.dumps({"type": "generated-image", "url": url}))
+        return {"success": True, "url": url}
+    except Exception as e:
+        logging.error(f"Image generation failed: {e}")
+        raise HTTPException(status_code=500, detail="Image generation failed")

--- a/prototype/frontend/src/App.tsx
+++ b/prototype/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import ModelAnalyzerTool from './components/ModelAnalyzerTool'
 import ErrorBoundary from './components/ErrorBoundary'
 import { ToastContainer } from './components/Toast'
 import FloatingChatWindow from './components/FloatingChatWindow'
+import ImageOverlay from './components/ImageOverlay'
 import SettingsPanel from './components/SettingsPanel'
 import BackgroundSoundSystem from './components/BackgroundSoundSystem'
 import DirectorMonitorHUD from './components/DirectorMonitorHUD'
@@ -527,8 +528,9 @@ function App() {
           toggleSettingsPanel={toggleSettingsPanel}
           toggleRoomControlPanel={useStore((state) => state.toggleRoomControlPanel)}
         />
-        
+
         <ToastContainer />
+        <ImageOverlay />
         <DirectorMonitorHUD />
         <DirectorLogPanel />
       </div>

--- a/prototype/frontend/src/components/ImageOverlay.tsx
+++ b/prototype/frontend/src/components/ImageOverlay.tsx
@@ -5,8 +5,17 @@ const DISPLAY_TIME = 10000; // ms
 // 後端 API 基礎 URL
 const API_BASE_URL = `http://${window.location.hostname}:8000`;
 
+interface ImageData {
+  url: string;
+  caption?: string;
+  display_config?: {
+    position?: { [key: string]: string };
+    size?: { [key: string]: string };
+  };
+}
+
 const ImageOverlay: React.FC = () => {
-  const [image, setImage] = useState<string | null>(null);
+  const [imageData, setImageData] = useState<ImageData | null>(null);
 
   useEffect(() => {
     const service = WebSocketService.getInstance();
@@ -17,8 +26,14 @@ const ImageOverlay: React.FC = () => {
         const fullImageUrl = data.url.startsWith('http') 
           ? data.url 
           : `${API_BASE_URL}${data.url}`;
-        setImage(fullImageUrl);
-        setTimeout(() => setImage(null), DISPLAY_TIME);
+        
+        setImageData({
+          url: fullImageUrl,
+          caption: data.caption,
+          display_config: data.display_config
+        });
+        
+        setTimeout(() => setImageData(null), DISPLAY_TIME);
       }
     };
 
@@ -28,7 +43,28 @@ const ImageOverlay: React.FC = () => {
     };
   }, []);
 
-  if (!image) return null;
+  if (!imageData) return null;
+
+  // 獲取樣式配置
+  const getStyles = () => {
+    const defaultPosition = { top: "50%", right: "50px", transform: "translateY(-50%)" };
+    const defaultSize = { width: "350px", height: "280px" };
+    
+    const position = imageData.display_config?.position || defaultPosition;
+    const size = imageData.display_config?.size || defaultSize;
+    
+    return {
+      ...position,
+      ...size,
+      position: 'fixed' as const,
+      borderRadius: '15px',
+      overflow: 'hidden',
+      boxShadow: '0 8px 32px rgba(0, 0, 0, 0.4)',
+      border: '2px solid rgba(255, 255, 255, 0.3)',
+      backdropFilter: 'blur(10px)',
+      zIndex: 1000,
+    };
+  };
 
   return (
     <>
@@ -44,30 +80,46 @@ const ImageOverlay: React.FC = () => {
               opacity: 1;
             }
           }
-          .image-overlay {
+          @keyframes slideInFromLeft {
+            from {
+              transform: translateX(-100%);
+              opacity: 0;
+            }
+            to {
+              transform: translateX(0);
+              opacity: 1;
+            }
+          }
+          @keyframes fadeIn {
+            from {
+              opacity: 0;
+              transform: scale(0.8);
+            }
+            to {
+              opacity: 1;
+              transform: scale(1);
+            }
+          }
+          .image-overlay-right {
             animation: slideInFromRight 0.5s ease-out;
+          }
+          .image-overlay-left {
+            animation: slideInFromLeft 0.5s ease-out;
+          }
+          .image-overlay-center {
+            animation: fadeIn 0.5s ease-out;
           }
         `}
       </style>
       <div
-        className="image-overlay"
-        style={{
-          position: 'fixed',
-          top: '50%',
-          right: '50px',
-          transform: 'translateY(-50%)',
-          width: '350px',
-          height: '280px',
-          borderRadius: '15px',
-          overflow: 'hidden',
-          boxShadow: '0 8px 32px rgba(0, 0, 0, 0.4)',
-          border: '2px solid rgba(255, 255, 255, 0.3)',
-          backdropFilter: 'blur(10px)',
-          zIndex: 1000,
-        }}
+        className={`image-overlay-${
+          imageData.display_config?.position?.right ? 'right' : 
+          imageData.display_config?.position?.left ? 'left' : 'center'
+        }`}
+        style={getStyles()}
       >
         <img 
-          src={image} 
+          src={imageData.url} 
           alt="Generated" 
           style={{ 
             width: '100%', 
@@ -76,11 +128,11 @@ const ImageOverlay: React.FC = () => {
             borderRadius: '13px'
           }}
           onError={(e) => {
-            console.error('圖片載入失敗:', image);
+            console.error('圖片載入失敗:', imageData.url);
             console.error('錯誤詳情:', e);
           }}
           onLoad={() => {
-            console.log('圖片載入成功:', image);
+            console.log('圖片載入成功:', imageData.url);
           }}
         />
         {/* 添加一個小標籤顯示這是 AI 生成的圖片 */}
@@ -99,6 +151,28 @@ const ImageOverlay: React.FC = () => {
         >
           AI 生成
         </div>
+        {/* 如果有 caption，顯示在右下角 */}
+        {imageData.caption && (
+          <div
+            style={{
+              position: 'absolute',
+              bottom: '8px',
+              right: '8px',
+              backgroundColor: 'rgba(0, 0, 0, 0.7)',
+              color: 'white',
+              padding: '4px 8px',
+              borderRadius: '8px',
+              fontSize: '10px',
+              maxWidth: '60%',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+            title={imageData.caption}
+          >
+            💬
+          </div>
+        )}
       </div>
     </>
   );

--- a/prototype/frontend/src/components/ImageOverlay.tsx
+++ b/prototype/frontend/src/components/ImageOverlay.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import WebSocketService from '../services/WebSocketService';
+
+const DISPLAY_TIME = 10000; // ms
+
+const ImageOverlay: React.FC = () => {
+  const [image, setImage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const service = WebSocketService.getInstance();
+
+    const handler = (data: any) => {
+      if (data.type === 'generated-image' && data.url) {
+        setImage(data.url);
+        setTimeout(() => setImage(null), DISPLAY_TIME);
+      }
+    };
+
+    service.registerHandler('generated-image', handler);
+    return () => {
+      service.removeHandler('generated-image', handler);
+    };
+  }, []);
+
+  if (!image) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(0,0,0,0.6)',
+        zIndex: 1000,
+      }}
+    >
+      <img src={image} alt="Generated" style={{ maxWidth: '90%', maxHeight: '90%' }} />
+    </div>
+  );
+};
+
+export default ImageOverlay;

--- a/prototype/frontend/src/components/ImageOverlay.tsx
+++ b/prototype/frontend/src/components/ImageOverlay.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import WebSocketService from '../services/WebSocketService';
 
 const DISPLAY_TIME = 10000; // ms
+// 後端 API 基礎 URL
+const API_BASE_URL = `http://${window.location.hostname}:8000`;
 
 const ImageOverlay: React.FC = () => {
   const [image, setImage] = useState<string | null>(null);
@@ -11,7 +13,11 @@ const ImageOverlay: React.FC = () => {
 
     const handler = (data: any) => {
       if (data.type === 'generated-image' && data.url) {
-        setImage(data.url);
+        // 將相對路徑轉換為完整的 URL
+        const fullImageUrl = data.url.startsWith('http') 
+          ? data.url 
+          : `${API_BASE_URL}${data.url}`;
+        setImage(fullImageUrl);
         setTimeout(() => setImage(null), DISPLAY_TIME);
       }
     };
@@ -25,22 +31,76 @@ const ImageOverlay: React.FC = () => {
   if (!image) return null;
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: 'rgba(0,0,0,0.6)',
-        zIndex: 1000,
-      }}
-    >
-      <img src={image} alt="Generated" style={{ maxWidth: '90%', maxHeight: '90%' }} />
-    </div>
+    <>
+      <style>
+        {`
+          @keyframes slideInFromRight {
+            from {
+              transform: translateX(100%);
+              opacity: 0;
+            }
+            to {
+              transform: translateX(0);
+              opacity: 1;
+            }
+          }
+          .image-overlay {
+            animation: slideInFromRight 0.5s ease-out;
+          }
+        `}
+      </style>
+      <div
+        className="image-overlay"
+        style={{
+          position: 'fixed',
+          top: '50%',
+          right: '50px',
+          transform: 'translateY(-50%)',
+          width: '350px',
+          height: '280px',
+          borderRadius: '15px',
+          overflow: 'hidden',
+          boxShadow: '0 8px 32px rgba(0, 0, 0, 0.4)',
+          border: '2px solid rgba(255, 255, 255, 0.3)',
+          backdropFilter: 'blur(10px)',
+          zIndex: 1000,
+        }}
+      >
+        <img 
+          src={image} 
+          alt="Generated" 
+          style={{ 
+            width: '100%', 
+            height: '100%', 
+            objectFit: 'cover',
+            borderRadius: '13px'
+          }}
+          onError={(e) => {
+            console.error('圖片載入失敗:', image);
+            console.error('錯誤詳情:', e);
+          }}
+          onLoad={() => {
+            console.log('圖片載入成功:', image);
+          }}
+        />
+        {/* 添加一個小標籤顯示這是 AI 生成的圖片 */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: '8px',
+            left: '8px',
+            backgroundColor: 'rgba(0, 0, 0, 0.7)',
+            color: 'white',
+            padding: '4px 8px',
+            borderRadius: '8px',
+            fontSize: '12px',
+            fontWeight: 'bold',
+          }}
+        >
+          AI 生成
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/prototype/frontend/src/components/__tests__/ImageOverlay.test.tsx
+++ b/prototype/frontend/src/components/__tests__/ImageOverlay.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import ImageOverlay from '../ImageOverlay';
+import WebSocketService from '../../services/WebSocketService';
+
+jest.useFakeTimers();
+
+jest.mock('../../services/WebSocketService');
+
+test('displays image on message and hides after timeout', () => {
+  const handlers: Record<string, (d: any) => void> = {};
+  (WebSocketService.getInstance as jest.Mock).mockReturnValue({
+    registerHandler: (type: string, h: any) => {
+      handlers[type] = h;
+    },
+    removeHandler: () => {},
+  });
+
+  render(<ImageOverlay />);
+
+  act(() => {
+    handlers['generated-image']?.({ type: 'generated-image', url: '/test.png' });
+  });
+
+  expect(screen.getByAltText('Generated')).toBeInTheDocument();
+
+  act(() => {
+    jest.advanceTimersByTime(10000);
+  });
+
+  expect(screen.queryByAltText('Generated')).toBeNull();
+});


### PR DESCRIPTION
## Summary
- support `/api/generate-image` to create images using Gemini
- broadcast newly created image path via WebSocket
- show generated images in a new `ImageOverlay` React component
- document the new API
- add integration and component tests

## Testing
- `black api/endpoints/image_generation.py api/__init__.py`
- `isort api/endpoints/image_generation.py api/__init__.py`
- `mypy api/endpoints/image_generation.py api/__init__.py` *(fails: missing stubs)*
- `pytest` *(no tests found)*
- `npm run lint:fix` *(fails: missing @eslint/js)*
- `npm run format` *(fails: invalid Prettier config)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444683c2d08321a3873fb93065fe9a