### PR TITLE
Enable timed image overlays

### DIFF
--- a/docs/backend/cursor_api_control_response_guidelines.md
+++ b/docs/backend/cursor_api_control_response_guidelines.md
@@ -261,10 +261,9 @@ To help Cursor better understand and utilize project assets, here are some key p
 - Generated images are automatically saved to `prototype/backend/generated_images/` directory
 - Images are accessible via HTTP at `http://localhost:8000{url}` (e.g., `http://localhost:8000/generated-images/image_1234567890.png`)
 - Images are automatically broadcasted via WebSocket to connected frontends with message type `generated-image`
-- Frontend `ImageOverlay` component will display generated images for 10 seconds automatically
+- Frontend `ImageOverlay` component displays each generated image for the `duration` specified by the backend (default 10 seconds)
 
 ## 🎉 Best Practices for a Smooth Show! 🎉
-
 1.  **Always Verify Connection Status First!**
     -   Before sending any commands, especially at the start of a sequence, call `GET /api/control/status` to ensure there's an active frontend connection. If `active_connections` is 0, commands won't be received.
 
@@ -718,7 +717,7 @@ sleep 5
 -   Format: PNG with RGB color space
 -   Storage location: `prototype/backend/generated_images/`
 -   Accessible via: `http://localhost:8000/generated-images/{filename}`
--   Frontend display: Automatically shown in `ImageOverlay` component for 10 seconds
+-   Frontend display: Shown in `ImageOverlay` component for the backend-provided `duration` (default 10 seconds)
 -   WebSocket broadcast: Images are broadcasted with type `generated-image` including URL, caption, and display_config
 -   Position control: 7 preset positions (center-right default) plus custom positioning
 -   Size control: 3 preset sizes (medium default) plus custom sizing

--- a/docs/backend/image_generation_api.md
+++ b/docs/backend/image_generation_api.md
@@ -12,7 +12,8 @@
 
 ```json
 {
-  "description": "一段描述文字"
+  "description": "一段描述文字",
+  "duration": 5.0
 }
 ```
 
@@ -21,7 +22,8 @@
 ```json
 {
   "success": true,
-  "url": "/generated-images/image_1700000000000.png"
+  "url": "/generated-images/image_1700000000000.png",
+  "duration": 5.0
 }
 ```
 

--- a/integration_tests/image_generation/test_image_generation_api.py
+++ b/integration_tests/image_generation/test_image_generation_api.py
@@ -16,22 +16,24 @@ IMAGE_DIR = "prototype/backend/generated_images"
 
 
 def test_generate_image_api():
-    payload = {"description": "simple test pattern"}
+    payload = {"description": "simple test pattern", "duration": 1.5}
     response = requests.post(ENDPOINT, json=payload)
     assert response.status_code == 200
     data = response.json()
     assert "url" in data
     filename = data["url"].split("/generated-images/")[-1]
     assert os.path.exists(os.path.join(IMAGE_DIR, filename))
+    assert data.get("duration") == 1.5
 
 
 async def test_websocket_notification():
     async with websockets.connect(WS_URL) as ws:
-        requests.post(ENDPOINT, json={"description": "ws image"})
+        requests.post(ENDPOINT, json={"description": "ws image", "duration": 2})
         message = await asyncio.wait_for(ws.recv(), timeout=10)
         data = json.loads(message)
         assert data.get("type") == "generated-image"
         assert "url" in data
+        assert data.get("duration") == 2
 
 
 if __name__ == "__main__":

--- a/prototype/backend/api/endpoints/image_generation.py
+++ b/prototype/backend/api/endpoints/image_generation.py
@@ -37,6 +37,8 @@ class ImageGenerationRequest(BaseModel):
     custom_position: Optional[dict] = None  # {"top": "50%", "right": "50px", "transform": "translateY(-50%)"}
     # 自定義大小 (可選，優先於 size)
     custom_size: Optional[dict] = None  # {"width": "350px", "height": "280px"}
+    # 顯示持續時間 (可選，秒)
+    duration: Optional[float] = 10.0
 
 
 @router.post("/generate-image")
@@ -76,20 +78,22 @@ async def generate_image(request: ImageGenerationRequest):
         
         # 處理位置和大小設定
         display_config = _get_display_config(request)
-        
+
         # 透過WebSocket廣播結果，包含顯示配置
         await manager.broadcast(json.dumps({
-            "type": "generated-image", 
+            "type": "generated-image",
             "url": url,
             "caption": caption,
-            "display_config": display_config
+            "display_config": display_config,
+            "duration": request.duration
         }))
-        
+
         return {
-            "success": True, 
-            "url": url, 
+            "success": True,
+            "url": url,
             "caption": caption,
-            "display_config": display_config
+            "display_config": display_config,
+            "duration": request.duration
         }
         
     except Exception as e:

--- a/prototype/frontend/src/components/ImageOverlay.tsx
+++ b/prototype/frontend/src/components/ImageOverlay.tsx
@@ -1,11 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import WebSocketService from '../services/WebSocketService';
 
-const DISPLAY_TIME = 10000; // ms
+const DEFAULT_DISPLAY_TIME = 10000; // ms
 // 後端 API 基礎 URL
 const API_BASE_URL = `http://${window.location.hostname}:8000`;
 
 interface ImageData {
+  id: string;
   url: string;
   caption?: string;
   display_config?: {
@@ -15,7 +16,8 @@ interface ImageData {
 }
 
 const ImageOverlay: React.FC = () => {
-  const [imageData, setImageData] = useState<ImageData | null>(null);
+  const [images, setImages] = useState<ImageData[]>([]);
+  const timers = useRef<Record<string, NodeJS.Timeout>>({});
 
   useEffect(() => {
     const service = WebSocketService.getInstance();
@@ -27,13 +29,20 @@ const ImageOverlay: React.FC = () => {
           ? data.url 
           : `${API_BASE_URL}${data.url}`;
         
-        setImageData({
-          url: fullImageUrl,
-          caption: data.caption,
-          display_config: data.display_config
+        const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const duration = typeof data.duration === 'number' ? data.duration * 1000 : DEFAULT_DISPLAY_TIME;
+
+        setImages((prev) => {
+          // 移除同 URL 的現有圖片，以支援覆蓋
+          const filtered = prev.filter((img) => img.url !== fullImageUrl);
+          return [...filtered, { id, url: fullImageUrl, caption: data.caption, display_config: data.display_config }];
         });
-        
-        setTimeout(() => setImageData(null), DISPLAY_TIME);
+
+        if (timers.current[id]) clearTimeout(timers.current[id]);
+        timers.current[id] = setTimeout(() => {
+          setImages((prev) => prev.filter((img) => img.id !== id));
+          delete timers.current[id];
+        }, duration);
       }
     };
 
@@ -43,15 +52,15 @@ const ImageOverlay: React.FC = () => {
     };
   }, []);
 
-  if (!imageData) return null;
+  if (images.length === 0) return null;
 
   // 獲取樣式配置
-  const getStyles = () => {
+  const getStyles = (img: ImageData) => {
     const defaultPosition = { top: "50%", right: "50px", transform: "translateY(-50%)" };
     const defaultSize = { width: "350px", height: "280px" };
     
-    const position = imageData.display_config?.position || defaultPosition;
-    const size = imageData.display_config?.size || defaultSize;
+    const position = img.display_config?.position || defaultPosition;
+    const size = img.display_config?.size || defaultSize;
     
     return {
       ...position,
@@ -111,28 +120,30 @@ const ImageOverlay: React.FC = () => {
           }
         `}
       </style>
-      <div
-        className={`image-overlay-${
-          imageData.display_config?.position?.right ? 'right' : 
-          imageData.display_config?.position?.left ? 'left' : 'center'
-        }`}
-        style={getStyles()}
-      >
-        <img 
-          src={imageData.url} 
-          alt="Generated" 
-          style={{ 
-            width: '100%', 
-            height: '100%', 
+      {images.map((img) => (
+        <div
+          key={img.id}
+          className={`image-overlay-${
+            img.display_config?.position?.right ? 'right' :
+            img.display_config?.position?.left ? 'left' : 'center'
+          }`}
+          style={getStyles(img)}
+        >
+          <img
+            src={img.url}
+          alt="Generated"
+          style={{
+            width: '100%',
+            height: '100%',
             objectFit: 'cover',
             borderRadius: '13px'
           }}
           onError={(e) => {
-            console.error('圖片載入失敗:', imageData.url);
+            console.error('圖片載入失敗:', img.url);
             console.error('錯誤詳情:', e);
           }}
           onLoad={() => {
-            console.log('圖片載入成功:', imageData.url);
+            console.log('圖片載入成功:', img.url);
           }}
         />
         {/* 添加一個小標籤顯示這是 AI 生成的圖片 */}
@@ -152,7 +163,7 @@ const ImageOverlay: React.FC = () => {
           AI 生成
         </div>
         {/* 如果有 caption，顯示在右下角 */}
-        {imageData.caption && (
+        {img.caption && (
           <div
             style={{
               position: 'absolute',
@@ -168,12 +179,13 @@ const ImageOverlay: React.FC = () => {
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
             }}
-            title={imageData.caption}
+            title={img.caption}
           >
             💬
           </div>
         )}
-      </div>
+        </div>
+      ))}
     </>
   );
 };

--- a/prototype/frontend/src/components/__tests__/ImageOverlay.test.tsx
+++ b/prototype/frontend/src/components/__tests__/ImageOverlay.test.tsx
@@ -19,13 +19,44 @@ test('displays image on message and hides after timeout', () => {
   render(<ImageOverlay />);
 
   act(() => {
-    handlers['generated-image']?.({ type: 'generated-image', url: '/test.png' });
+    handlers['generated-image']?.({ type: 'generated-image', url: '/test.png', duration: 1 });
   });
 
   expect(screen.getByAltText('Generated')).toBeInTheDocument();
 
   act(() => {
-    jest.advanceTimersByTime(10000);
+    jest.advanceTimersByTime(1000);
+  });
+
+  expect(screen.queryByAltText('Generated')).toBeNull();
+});
+
+test('supports multiple images with independent durations', () => {
+  const handlers: Record<string, (d: any) => void> = {};
+  (WebSocketService.getInstance as jest.Mock).mockReturnValue({
+    registerHandler: (type: string, h: any) => {
+      handlers[type] = h;
+    },
+    removeHandler: () => {},
+  });
+
+  render(<ImageOverlay />);
+
+  act(() => {
+    handlers['generated-image']?.({ type: 'generated-image', url: '/one.png', duration: 1 });
+    handlers['generated-image']?.({ type: 'generated-image', url: '/two.png', duration: 2 });
+  });
+
+  expect(screen.getAllByAltText('Generated')).toHaveLength(2);
+
+  act(() => {
+    jest.advanceTimersByTime(1000);
+  });
+
+  expect(screen.getAllByAltText('Generated')).toHaveLength(1);
+
+  act(() => {
+    jest.advanceTimersByTime(1000);
   });
 
   expect(screen.queryByAltText('Generated')).toBeNull();


### PR DESCRIPTION
## Summary
- add `duration` field to `/generate-image` API
- broadcast duration to clients and document usage
- update ImageOverlay component to manage multiple timed images
- extend tests for new dynamic overlay timing
- adjust documentation

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `python3 integration_tests/image_generation/test_image_generation_api.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6844fd4c32908321b10116b97d8189f0