### PR TITLE
Implement toggle for realtime voice

### DIFF
--- a/docs/frontend/realtime_voice_module.md
+++ b/docs/frontend/realtime_voice_module.md
@@ -10,7 +10,7 @@ import { useRealtimeVoice } from '@/services';
 const { start, stop, streaming } = useRealtimeVoice();
 ```
 
-在介面上提供一個獨立的麥克風按鈕，按下開始串流，放開即停止。
+介面提供可切換的麥克風按鈕或使用空白鍵觸發。按一次啟動串流，再按一次立即停止。
 
 預設會連線至 `ws://<host>/api/real-time/ws` WebSocket 端點。
 

--- a/prototype/frontend/src/App.tsx
+++ b/prototype/frontend/src/App.tsx
@@ -101,8 +101,32 @@ function App() {
     playAudio
   } = useAudioService();
 
-  const { start: startRealtime, stop: stopRealtime, streaming: realtimeStreaming, error: realtimeError } =
-    useRealtimeVoice();
+  const {
+    start: startRealtime,
+    stop: stopRealtime,
+    streaming: realtimeStreaming,
+    error: realtimeError,
+  } = useRealtimeVoice();
+
+  const toggleRealtime = useCallback(() => {
+    if (realtimeStreaming) {
+      stopRealtime();
+    } else {
+      startRealtime();
+    }
+  }, [realtimeStreaming, startRealtime, stopRealtime]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (e.code === 'Space' && !e.repeat && target.tagName !== 'INPUT' && !target.isContentEditable) {
+        e.preventDefault();
+        toggleRealtime();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [toggleRealtime]);
   
   // --- 使用頭部服務 (替換 useModelService) ---
   const {
@@ -531,8 +555,7 @@ function App() {
           toggleChatWindow={toggleChatWindow}
           toggleSettingsPanel={toggleSettingsPanel}
           toggleRoomControlPanel={useStore((state) => state.toggleRoomControlPanel)}
-          startRealtime={startRealtime}
-          stopRealtime={stopRealtime}
+          toggleRealtime={toggleRealtime}
           realtimeStreaming={realtimeStreaming}
           realtimeError={realtimeError}
         />

--- a/prototype/frontend/src/components/layout/AppUI.tsx
+++ b/prototype/frontend/src/components/layout/AppUI.tsx
@@ -56,8 +56,7 @@ interface AppUIProps {
   toggleSettingsPanel: () => void;
   // 房間控制面板控制
   toggleRoomControlPanel: () => void;
-  startRealtime: () => void;
-  stopRealtime: () => void;
+  toggleRealtime: () => void;
   realtimeStreaming: boolean;
   realtimeError: string | null;
 }
@@ -74,8 +73,7 @@ const AppUI: React.FC<AppUIProps> = ({
   toggleSettingsPanel,
   // 房間控制面板控制
   toggleRoomControlPanel,
-  startRealtime,
-  stopRealtime,
+  toggleRealtime,
   realtimeStreaming,
   realtimeError,
 }) => {
@@ -124,23 +122,19 @@ const AppUI: React.FC<AppUIProps> = ({
         {/* Real-time Voice Button */}
         <div className="flex flex-col items-end">
           <button
-            onMouseDown={startRealtime}
-            onMouseUp={stopRealtime}
-            onTouchStart={startRealtime}
-            onTouchEnd={stopRealtime}
-            onMouseLeave={realtimeStreaming ? stopRealtime : undefined}
+            onClick={toggleRealtime}
             className={`
               relative w-12 h-12 rounded-full shadow-md flex items-center justify-center cursor-pointer transition-all duration-200
-              ${realtimeStreaming 
-                ? 'bg-red-600 hover:bg-red-700 animate-pulse ring-2 ring-red-300' 
+              ${realtimeStreaming
+                ? 'bg-red-600 hover:bg-red-700 animate-pulse ring-2 ring-red-300'
                 : realtimeError
-                ? 'bg-red-400 hover:bg-red-500'
-                : 'bg-red-500 hover:bg-red-600'
+                  ? 'bg-red-400 hover:bg-red-500'
+                  : 'bg-red-500 hover:bg-red-600'
               }
               text-white text-2xl
             `}
-            title={realtimeStreaming ? "正在實時語音通話 - 鬆開停止" : "按住開始實時語音"}
-            aria-label={realtimeStreaming ? "正在實時語音通話 - 鬆開停止" : "按住開始實時語音"}
+            title={realtimeStreaming ? '停止實時語音通話 (空白鍵)' : '啟動實時語音通話 (空白鍵)'}
+            aria-label={realtimeStreaming ? '停止實時語音通話 (空白鍵)' : '啟動實時語音通話 (空白鍵)'}
           >
             {realtimeStreaming ? '🔴' : '🎤'}
             {realtimeStreaming && (


### PR DESCRIPTION
## Summary
- toggle realtime conversation with spacebar or button click
- provide visual cue and key hint for the microphone button
- document the new toggle behaviour

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: react-scripts not found)*
- `pytest`
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846c1f4bbf8832189849eba89f5be87