### PR TITLE
Configure realtime response language

### DIFF
--- a/docs/backend/realtime_conversation_api.md
+++ b/docs/backend/realtime_conversation_api.md
@@ -15,4 +15,32 @@
 3. 服務會將收到的語音即時轉寫並透過 OpenAI Real‑time API 產生回覆。
 4. 產生的語音會以二進位形式持續傳回，前端可即時播放並同步頭部動畫。
 
+## Configuration
+
+```json
+{
+  "model": "gpt-4o-realtime-preview",
+  "voice": "alloy",
+  "turn_detection": {
+    "type": "server_vad",
+    "threshold": 0.5,
+    "prefix_padding_ms": 300,
+    "silence_duration_ms": 500
+  },
+  "transcript_model": "whisper-1",
+  "noise_reduction": "none",
+  "temperature": 0.84,
+  "max_tokens": 4096
+}
+```
+
+模型將以臺灣閩南語、親切且情感豐富的語氣快速回應，內容保持簡短。
+
+### Example
+
+- User: "What do you think about spicy food?"
+  - Assistant: "辣味好食, 小心喔!"
+- User: "How's the weather today?"
+  - Assistant: "今天天氣無錯啦。"
+
 

--- a/prototype/backend/services/realtime_conversation.py
+++ b/prototype/backend/services/realtime_conversation.py
@@ -1,17 +1,16 @@
 import asyncio
-import logging
-from typing import AsyncIterator, AsyncGenerator
-import io
 import base64
-import wave
-import struct
+import io
 import json
-import websockets
-from websockets.exceptions import ConnectionClosed
+import logging
+import struct
+import wave
+from typing import AsyncGenerator, AsyncIterator
 
 import openai
-
+import websockets
 from core.config import settings
+from websockets.exceptions import ConnectionClosed
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +33,7 @@ class RealtimeConversationService:
         except Exception as exc:  # pragma: no cover - network
             logger.error("Realtime conversation failed: %s", exc)
             logger.info("Falling back to test mode...")
-            
+
             # 回退到測試模式
             self.test_mode = True
             async for test_audio in self._test_conversation(audio_chunks):
@@ -44,33 +43,39 @@ class RealtimeConversationService:
         self, audio_chunks: AsyncIterator[bytes]
     ) -> AsyncGenerator[bytes, None]:
         """使用 WebSocket 連接到 OpenAI Realtime API"""
-        url = "wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01"
+        url = "wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview"
         headers = {
             "Authorization": f"Bearer {settings.OPENAI_API_KEY}",
-            "OpenAI-Beta": "realtime=v1"
+            "OpenAI-Beta": "realtime=v1",
         }
-        
+
         logger.info("Connecting to OpenAI Realtime API via WebSocket...")
-        
+
         try:
             async with websockets.connect(url, additional_headers=headers) as ws:
                 logger.info("Connected to OpenAI Realtime API")
-                
+
                 # 發送初始會話配置
                 await self._send_session_update(ws)
-                
+
                 # 創建音頻接收隊列
                 audio_queue = asyncio.Queue()
-                
+
                 # 啟動並行任務
-                send_task = asyncio.create_task(self._send_audio_to_openai(ws, audio_chunks))
-                receive_task = asyncio.create_task(self._receive_openai_responses(ws, audio_queue))
-                
+                send_task = asyncio.create_task(
+                    self._send_audio_to_openai(ws, audio_chunks)
+                )
+                receive_task = asyncio.create_task(
+                    self._receive_openai_responses(ws, audio_queue)
+                )
+
                 try:
                     # 從隊列中讀取音頻回應
                     while True:
                         try:
-                            audio_data = await asyncio.wait_for(audio_queue.get(), timeout=1.0)
+                            audio_data = await asyncio.wait_for(
+                                audio_queue.get(), timeout=1.0
+                            )
                             if audio_data is None:  # 結束信號
                                 break
                             yield audio_data
@@ -79,14 +84,14 @@ class RealtimeConversationService:
                             if receive_task.done() or send_task.done():
                                 break
                             continue
-                            
+
                 except asyncio.CancelledError:
                     logger.info("Realtime conversation cancelled")
                 finally:
                     # 取消所有任務
                     receive_task.cancel()
                     send_task.cancel()
-                    
+
         except ConnectionClosed:
             logger.error("WebSocket connection to OpenAI was closed")
             raise
@@ -99,18 +104,23 @@ class RealtimeConversationService:
         session_event = {
             "type": "session.update",
             "session": {
+                "model": "gpt-4o-realtime-preview",
                 "modalities": ["audio", "text"],
-                "instructions": "你是一個有用的AI助手。請用中文簡短回應，避免過長的回答。",
+                "instructions": "請以臺灣閩南語回應，語氣親切且富有情感，語速快但保持簡短。",
                 "voice": "alloy",
+                "temperature": 0.84,
+                "max_tokens": 4096,
                 "input_audio_format": "pcm16",
                 "output_audio_format": "pcm16",
+                "transcript_model": "whisper-1",
+                "noise_reduction": "none",
                 "turn_detection": {
                     "type": "server_vad",
-                    "threshold": 0.6,
+                    "threshold": 0.5,
                     "prefix_padding_ms": 300,
-                    "silence_duration_ms": 1000
-                }
-            }
+                    "silence_duration_ms": 500,
+                },
+            },
         }
         await ws.send(json.dumps(session_event))
         logger.info("Sent session configuration to OpenAI")
@@ -124,17 +134,19 @@ class RealtimeConversationService:
                     chunk_count += 1
                     # 前端現在直接發送 PCM16 格式的音頻位元組數據
                     # 直接進行 base64 編碼並發送到 OpenAI
-                    base64_audio = base64.b64encode(chunk).decode('utf-8')
+                    base64_audio = base64.b64encode(chunk).decode("utf-8")
                     audio_event = {
                         "type": "input_audio_buffer.append",
-                        "audio": base64_audio
+                        "audio": base64_audio,
                     }
                     await ws.send(json.dumps(audio_event))
-                    logger.info(f"Sent audio chunk #{chunk_count}: {len(chunk)} bytes (PCM16 format)")
-                    
+                    logger.info(
+                        f"Sent audio chunk #{chunk_count}: {len(chunk)} bytes (PCM16 format)"
+                    )
+
                     # 依賴 OpenAI 的 server_vad 自動檢測語音結束並回應
                     # 不再手動觸發回應
-                        
+
         except Exception as e:
             logger.error(f"Error sending audio to OpenAI: {e}")
 
@@ -145,40 +157,42 @@ class RealtimeConversationService:
                 try:
                     event = json.loads(message)
                     logger.debug(f"Received event: {event.get('type')}")
-                    
+
                     # 處理音頻回應
                     if event.get("type") == "response.audio.delta":
                         if "delta" in event:
                             # 解碼 base64 音頻數據
                             pcm_data = base64.b64decode(event["delta"])
-                            logger.info(f"Received PCM audio delta: {len(pcm_data)} bytes")
-                            
+                            logger.info(
+                                f"Received PCM audio delta: {len(pcm_data)} bytes"
+                            )
+
                             # 將 PCM16 數據轉換為 WAV 格式
                             wav_data = self._pcm_to_wav(pcm_data)
                             logger.info(f"Converted to WAV: {len(wav_data)} bytes")
                             await audio_queue.put(wav_data)
-                    
+
                     # 處理文本回應（用於調試）
                     elif event.get("type") == "response.text.delta":
                         logger.info(f"OpenAI text response: {event.get('delta', '')}")
-                    
+
                     # 處理錯誤
                     elif event.get("type") == "error":
                         logger.error(f"OpenAI API error: {event}")
-                        
+
                     # 處理會話創建
                     elif event.get("type") == "session.created":
                         logger.info("OpenAI session created successfully")
-                        
+
                     # 處理會話更新
                     elif event.get("type") == "session.updated":
                         logger.info("OpenAI session updated successfully")
-                        
+
                 except json.JSONDecodeError as e:
                     logger.error(f"Failed to parse JSON message: {e}")
                 except Exception as e:
                     logger.error(f"Error processing OpenAI response: {e}")
-                    
+
         except ConnectionClosed:
             logger.info("OpenAI WebSocket connection closed")
         except Exception as e:
@@ -190,24 +204,24 @@ class RealtimeConversationService:
     def _pcm_to_wav(self, pcm_data: bytes) -> bytes:
         """將 PCM16 數據轉換為 WAV 格式"""
         if not pcm_data:
-            return b''
-            
+            return b""
+
         # WAV 文件參數
         sample_rate = 24000  # OpenAI Realtime API 使用 24kHz
         channels = 1  # 單聲道
         sample_width = 2  # 16-bit
-        
+
         # 創建 WAV 文件
         wav_buffer = io.BytesIO()
-        with wave.open(wav_buffer, 'wb') as wav_file:
+        with wave.open(wav_buffer, "wb") as wav_file:
             wav_file.setnchannels(channels)
             wav_file.setsampwidth(sample_width)
             wav_file.setframerate(sample_rate)
             wav_file.writeframes(pcm_data)
-        
+
         wav_buffer.seek(0)
         wav_data = wav_buffer.getvalue()
-        
+
         return wav_data
 
     async def _test_conversation(
@@ -215,56 +229,66 @@ class RealtimeConversationService:
     ) -> AsyncGenerator[bytes, None]:
         """測試模式：模擬音頻回應"""
         logger.info("Running in test mode - generating simulated responses")
-        
+
         chunk_count = 0
         last_response_time = 0
-        
+
         async for chunk in audio_chunks:
             chunk_count += 1
             logger.info(f"Received audio chunk {chunk_count}: {len(chunk)} bytes")
-            
+
             # 每收到幾個音頻片段就生成一個測試回應
             if chunk_count % 8 == 0:  # 每8個chunk回應一次（約2秒）
                 # 生成一個簡單的測試音頻回應
                 test_response = self._generate_test_audio_response(chunk_count)
                 if test_response:
-                    logger.info(f"Sending test audio response #{chunk_count // 8}: {len(test_response)} bytes")
+                    logger.info(
+                        f"Sending test audio response #{chunk_count // 8}: {len(test_response)} bytes"
+                    )
                     yield test_response
-                    
+
                 # 添加小延遲模擬真實回應時間
                 await asyncio.sleep(0.1)
 
     def _generate_test_audio_response(self, chunk_count: int) -> bytes:
         """生成測試音頻回應 - 創建真實的可播放 WAV 音頻"""
         logger.info(f"Generating test audio response #{chunk_count // 8}")
-        
+
         # 生成一個簡短的 WAV 音頻文件（1秒的正弦波）
         sample_rate = 44100  # 44.1 kHz
         duration = 1.0  # 1 second
         frequency = 440  # A4 note (440 Hz)
-        
+
         # 生成正弦波數據
         samples = []
         for i in range(int(sample_rate * duration)):
             # 生成正弦波，音量逐漸減小避免突然中斷
             t = i / sample_rate
             amplitude = 0.3 * (1 - t / duration)  # 逐漸減小的音量
-            sample = amplitude * 32767 * (1 if i % (sample_rate // frequency) < (sample_rate // frequency // 2) else -1)
+            sample = (
+                amplitude
+                * 32767
+                * (
+                    1
+                    if i % (sample_rate // frequency) < (sample_rate // frequency // 2)
+                    else -1
+                )
+            )
             samples.append(int(sample))
-        
+
         # 創建 WAV 文件
         wav_buffer = io.BytesIO()
-        with wave.open(wav_buffer, 'wb') as wav_file:
+        with wave.open(wav_buffer, "wb") as wav_file:
             wav_file.setnchannels(1)  # 單聲道
             wav_file.setsampwidth(2)  # 16-bit
             wav_file.setframerate(sample_rate)
-            
+
             # 寫入音頻數據
             for sample in samples:
-                wav_file.writeframes(struct.pack('<h', sample))
-        
+                wav_file.writeframes(struct.pack("<h", sample))
+
         wav_buffer.seek(0)
         audio_data = wav_buffer.getvalue()
-        
+
         logger.info(f"Generated WAV audio: {len(audio_data)} bytes")
         return audio_data


### PR DESCRIPTION
## Summary
- tweak real-time websocket URL to gpt-4o-realtime-preview
- send session update requiring short Taiwanese Hokkien replies
- document real-time conversation configuration and examples

## Testing
- `black prototype/backend/services/realtime_conversation.py`
- `isort prototype/backend/services/realtime_conversation.py`
- `mypy prototype/backend/services/realtime_conversation.py` *(fails: cannot find module stubs)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: react-scripts not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846cae7551c832198dbb73e24757e47