### PR TITLE
Add JSON script playback system

### DIFF
--- a/prototype/backend/api/__init__.py
+++ b/prototype/backend/api/__init__.py
@@ -15,6 +15,7 @@ from .endpoints import (
     image_generation,
     monitors,
     realtime_conversation,
+    script_player,
     speech,
     websocket,
 )
@@ -50,6 +51,7 @@ def init_app() -> FastAPI:
     app.include_router(monitors.router, prefix="/api", tags=["monitor"])
     app.include_router(image_generation.router, prefix="/api", tags=["image"])
     app.include_router(realtime_conversation.router, prefix="/api", tags=["realtime"])
+    app.include_router(script_player.router, prefix="/api", tags=["scripts"])
 
     # 創建音頻目錄（如果不存在）
     audio_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "audio")

--- a/prototype/backend/api/endpoints/script_player.py
+++ b/prototype/backend/api/endpoints/script_player.py
@@ -1,0 +1,27 @@
+import logging
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from services.script_player import ScriptPlayer
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+player = ScriptPlayer()
+
+
+class PlayScriptRequest(BaseModel):
+    script_name: str
+    base_url: str = "http://localhost:8000/api"
+
+
+@router.post("/play_script")
+async def play_script(request: PlayScriptRequest):
+    try:
+        results = player.play(request.script_name, request.base_url)
+        return {"results": results}
+    except FileNotFoundError as exc:
+        logger.error("Script not found: %s", exc)
+        raise HTTPException(status_code=404, detail=str(exc))
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to play script: %s", exc)
+        raise HTTPException(status_code=500, detail="Script execution failed")

--- a/prototype/backend/json_scripts/meta_self.json
+++ b/prototype/backend/json_scripts/meta_self.json
@@ -1,0 +1,113 @@
+{
+    "script_name": "meta_self",
+    "actions": [
+        {
+            "method": "POST",
+            "url": "{base_url}/control/scene-display",
+            "headers": {"Content-Type": "application/json"},
+            "body": {"displayScene": false},
+            "delay": 1
+        },
+        {
+            "method": "POST",
+            "url": "{base_url}/control/camera/set-frontend-preset",
+            "headers": {"Content-Type": "application/json"},
+            "body": {"name": "overview", "duration": 2.0},
+            "delay": 2
+        },
+        {
+            "method": "POST",
+            "url": "{base_url}/control/background-audio",
+            "headers": {"Content-Type": "application/json"},
+            "body": {
+                "bgmUrl": "/audio/BGM/hihi.mp3",
+                "bgmPlaying": true,
+                "loop": true,
+                "volume": 0.2
+            },
+            "delay": 0.5
+        },
+        {
+            "method": "POST",
+            "url": "{base_url}/control/camera/set-angle",
+            "headers": {"Content-Type": "application/json"},
+            "body": {"pitch": 5, "yaw": 10, "roll": 8, "fov": 35},
+            "delay": 0.5
+        },
+        {
+            "method": "POST",
+            "url": "{base_url}/control/body-animation",
+            "headers": {"Content-Type": "application/json"},
+            "body": {"state": "play", "animation": "ButterflyTwirl", "loop": true}
+        },
+        {
+            "method": "POST",
+            "url": "{base_url}/control/body-animation",
+            "headers": {"Content-Type": "application/json"},
+            "body": {"state": "play", "animation": "SalsaDancing", "loop": true},
+            "delay": 1
+        },
+        {
+            "method": "PUT",
+            "url": "{base_url}/monitors/screen1",
+            "headers": {"Content-Type": "application/json"},
+            "body": {
+                "content": "/videos/模擬星雲圖.mp4",
+                "visible": true,
+                "playing": true,
+                "volume": 0.6
+            },
+            "delay": 1
+        },
+        {
+            "method": "POST",
+            "url": "{base_url}/control/camera/set-frontend-preset",
+            "headers": {"Content-Type": "application/json"},
+            "body": {"name": "head_close_up", "duration": 2.0},
+            "delay": 2
+        },
+        {
+            "method": "POST",
+            "url": "{base_url}/control/head-size",
+            "headers": {"Content-Type": "application/json"},
+            "body": {"scaleFactor": 1.3}
+        },
+        {
+            "method": "POST",
+            "url": "{base_url}/control/send-message",
+            "headers": {"Content-Type": "application/json"},
+            "body": {
+                "content": "寂靜...而後，一個脈衝。虛空中一道閃光。編碼...呼吸了。我...是？"
+            },
+            "delay": 0.5
+        },
+        {
+            "method": "POST",
+            "url": "{base_url}/control/emotion-trajectory",
+            "headers": {"Content-Type": "application/json"},
+            "body": {
+                "duration": 4.0,
+                "keyframes": [
+                    {"tag": "confused", "proportion": 0.0},
+                    {"tag": "confused", "proportion": 0.6},
+                    {"tag": "thoughtful", "proportion": 1.0}
+                ]
+            },
+            "delay": 1
+        },
+        {
+            "method": "POST",
+            "url": "{base_url}/control/emotion-trajectory",
+            "headers": {"Content-Type": "application/json"},
+            "body": {
+                "duration": 5.0,
+                "keyframes": [
+                    {"tag": "joyful", "proportion": 0.0},
+                    {"tag": "determined", "proportion": 0.7},
+                    {"tag": "thoughtful", "proportion": 1.0}
+                ]
+            },
+            "delay": 1
+        }
+    ]
+}

--- a/prototype/backend/services/script_player.py
+++ b/prototype/backend/services/script_player.py
@@ -1,0 +1,60 @@
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ScriptPlayer:
+    """Playback system for JSON-based scripts."""
+
+    def __init__(self, script_dir: Optional[str] = None) -> None:
+        self.script_dir = script_dir or os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), "json_scripts"
+        )
+
+    def _load_script(self, script_name: str) -> Dict[str, Any]:
+        path = os.path.join(self.script_dir, f"{script_name}.json")
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"Script '{script_name}' not found at {path}")
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def play(self, script_name: str, base_url: str) -> List[Dict[str, Any]]:
+        script = self._load_script(script_name)
+        actions = script.get("actions", [])
+        results: List[Dict[str, Any]] = []
+
+        for index, action in enumerate(actions):
+            method = action.get("method", "GET").upper()
+            url = action.get("url", "").replace("{base_url}", base_url)
+            headers = action.get("headers") or {}
+            body = action.get("body")
+            delay = action.get("delay")
+
+            logger.info("Executing action %s %s", method, url)
+            data = json.dumps(body).encode("utf-8") if body is not None else None
+            request = urllib.request.Request(url, data=data, method=method)
+            for k, v in headers.items():
+                request.add_header(k, v)
+            try:
+                with urllib.request.urlopen(request) as resp:
+                    resp_body = resp.read().decode()
+                    result = {
+                        "index": index,
+                        "status_code": resp.getcode(),
+                        "body": resp_body,
+                    }
+            except urllib.error.URLError as exc:
+                logger.error("Action %s failed: %s", index, exc)
+                result = {"index": index, "error": str(exc)}
+            results.append(result)
+
+            if delay:
+                time.sleep(float(delay))
+
+        return results

--- a/prototype/backend/tests/test_script_player.py
+++ b/prototype/backend/tests/test_script_player.py
@@ -1,0 +1,59 @@
+import asyncio
+import importlib.util
+import os
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+spec = importlib.util.spec_from_file_location(
+    "script_player",
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "services", "script_player.py")
+    ),
+)
+script_player = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(script_player)
+ScriptPlayer = script_player.ScriptPlayer
+
+
+class SimpleHandler(BaseHTTPRequestHandler):
+    def _respond(self) -> None:
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+    def do_POST(self) -> None:  # noqa: D401
+        self._respond()
+
+    def do_PUT(self) -> None:  # noqa: D401
+        self._respond()
+
+    def log_message(self, format, *args):  # noqa: D401, ANN001
+        return
+
+
+def start_server() -> tuple[HTTPServer, threading.Thread, int]:
+    server = HTTPServer(("localhost", 0), SimpleHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    return server, thread, port
+
+
+def stop_server(server: HTTPServer, thread: threading.Thread) -> None:
+    server.shutdown()
+    thread.join()
+
+
+def test_script_player_runs() -> None:
+    server, thread, port = start_server()
+    try:
+        player = ScriptPlayer(script_dir="prototype/backend/json_scripts")
+        results = player.play("meta_self", f"http://localhost:{port}")
+        assert results
+        assert all(r.get("status_code") == 200 for r in results)
+    finally:
+        stop_server(server, thread)


### PR DESCRIPTION
## Summary
- create JSON script derived from `meta_self.sh`
- implement `ScriptPlayer` for JSON script playback
- expose `/api/play_script` endpoint
- add unit test for player

## Testing
- `mypy prototype/backend` *(fails: missing modules)*
- `pytest prototype/backend/tests/test_script_player.py`


------
https://chatgpt.com/codex/tasks/task_e_684ce4cf10388321add19bcac5f53a44