### PR TITLE
fix: remove light ws in favor of session control

### DIFF
--- a/prototype/backend/api/endpoints/physical_light_control.py
+++ b/prototype/backend/api/endpoints/physical_light_control.py
@@ -1,8 +1,7 @@
-from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from services.physical_light_control import PhysicalLightControlService
-import asyncio
 
 router = APIRouter(prefix="/physical-light", tags=["physical-light"])
 
@@ -14,12 +13,6 @@ class SetChannelBrightnessRequest(BaseModel):
     brightness: int = Field(..., description="通道 0 僅接受 0/1；通道 1-3 接受 0~65535")
 
 service = PhysicalLightControlService()
-
-# 亮度 WebSocket 串流的伺服器側保護開關（預設關閉，避免非會話期間噴發訊號）
-_BRIGHTNESS_STREAM_ENABLED = False
-
-class ToggleBrightnessStreamRequest(BaseModel):
-    enabled: bool = Field(..., description="是否允許透過 WS 傳入的亮度串流覆寫燈光")
 
 @router.post("/set-brightness")
 def set_brightness(req: SetBrightnessRequest):
@@ -33,69 +26,6 @@ def set_brightness(req: SetBrightnessRequest):
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"未知錯誤: {e}")
 
-# 新增 WebSocket 端點
-@router.websocket("/ws/brightness")
-async def websocket_brightness(websocket: WebSocket):
-    """接收前端的亮度流，但以固定頻率（預設 20Hz）批次套用最後一筆，避免高頻連發塞爆 serial 與日誌。"""
-    await websocket.accept()
-
-    latest_brightness: int = 0
-    applied_brightness: int = -1
-    stopped: bool = False
-    apply_interval_sec: float = 0.05  # 20Hz
-
-    async def apply_loop():
-        nonlocal applied_brightness
-        try:
-            while not stopped:
-                if _BRIGHTNESS_STREAM_ENABLED:
-                    # 僅在變化時才下發，避免重複寫入與日誌洪流
-                    if latest_brightness != applied_brightness:
-                        try:
-                            service.set_brightness(latest_brightness)
-                            applied_brightness = latest_brightness
-                        except Exception:
-                            # 出錯就嘗試關閉連線以自我修復
-                            service._close_serial_connection()
-                await asyncio.sleep(apply_interval_sec)
-        finally:
-            # 離開時確保關閉 serial
-            service._close_serial_connection()
-
-    loop_task = asyncio.create_task(apply_loop())
-
-    try:
-        while True:
-            data = await websocket.receive_json()
-            # 僅更新最新亮度；是否套用由 apply_loop 控制
-            br = data.get("brightness")
-            if isinstance(br, int):
-                if br < 0:
-                    br = 0
-                elif br > 65535:
-                    br = 65535
-                latest_brightness = br
-    except WebSocketDisconnect:
-        print("[WS] physical-light 斷線，清理資源...")
-    except Exception as e:
-        print(f"[WS] physical-light 控制錯誤: {e}")
-    finally:
-        print("[WS] physical-light WebSocket 結束，釋放所有資源")
-        stopped = True
-        try:
-            await loop_task
-        except Exception:
-            pass
-        service._close_serial_connection()
-
-@router.post("/toggle-brightness-stream")
-def toggle_brightness_stream(req: ToggleBrightnessStreamRequest):
-    """啟用/停用來自前端的亮度 WS 串流輸入。
-    - 會話開始時應啟用；會話結束時務必停用，避免後續殘留訊號。
-    """
-    global _BRIGHTNESS_STREAM_ENABLED
-    _BRIGHTNESS_STREAM_ENABLED = bool(req.enabled)
-    return {"success": True, "enabled": _BRIGHTNESS_STREAM_ENABLED}
 
 @router.post("/set-channel-brightness")
 def set_channel_brightness(req: SetChannelBrightnessRequest):

--- a/prototype/backend/services/realtime_conversation/websocket_handler.py
+++ b/prototype/backend/services/realtime_conversation/websocket_handler.py
@@ -216,16 +216,11 @@ class WebSocketHandler:
                     await self._reset_physical_light_connection()
                 except Exception as _e:
                     logger.warning(f"會話啟動前重置實體燈連線失敗: {_e}")
-                # 允許前端音量映射的亮度 WS 串流（只在會話期間）
+                # 新增：會話啟動時直接開啟物理燈光
                 try:
-                    import aiohttp
-                    async with aiohttp.ClientSession() as session:
-                        await session.post(
-                            "http://localhost:8000/api/physical-light/toggle-brightness-stream",
-                            json={"enabled": True}
-                        )
+                    await self._set_light_on()
                 except Exception as _e:
-                    logger.warning(f"啟用亮度串流失敗（可忽略）: {_e}")
+                    logger.warning(f"開啟燈光時發生例外: {_e}")
                 # 新增：設定初始環境光強度
                 await self._set_initial_environment_light()
                 # 新增：即時對話啟動時開啟招牌燈（channel 0 設為 1）
@@ -368,16 +363,6 @@ class WebSocketHandler:
                         await self._reset_physical_light_connection()
                     except Exception as _e:
                         logger.warning(f"重置實體燈連線時發生例外: {_e}")
-                    # 關閉前端亮度 WS 串流（避免對話結束後仍噴發）
-                    try:
-                        import aiohttp
-                        async with aiohttp.ClientSession() as session:
-                            await session.post(
-                                "http://localhost:8000/api/physical-light/toggle-brightness-stream",
-                                json={"enabled": False}
-                            )
-                    except Exception as _e:
-                        logger.warning(f"停用亮度串流失敗（可忽略）: {_e}")
                     # 變更：即時對話結束後不再恢復影片輪播，保持螢幕隱藏（inhibit 維持啟用）
                     logger.info("會話結束：不恢復影片輪播，保持螢幕關閉以符合待機需求")
                     
@@ -868,10 +853,17 @@ class WebSocketHandler:
                         logger.warning(f"重置環境光強度失敗: {await response.text()}")
         except Exception as e:
             logger.error(f"重置環境光強度異常: {e}")
-    
+
     def set_tool_executor(self, executor):
         """設定工具執行器"""
-        self.tool_executor = executor 
+        self.tool_executor = executor
+
+    async def _set_light_on(self):
+        """直接將燈光設為最大亮度"""
+        import aiohttp
+        base_url = "http://localhost:8000/api/physical-light/set-brightness"
+        async with aiohttp.ClientSession() as session:
+            await session.post(base_url, json={"brightness": 65535})
 
     async def _set_light_off(self):
         """直接將燈光設為 0（全暗）"""

--- a/prototype/frontend/src/components/layout/AppUI.tsx
+++ b/prototype/frontend/src/components/layout/AppUI.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 // import ChatInterface from '../ChatInterface'; // <-- Remove import
 // import ControlPanel from '../ControlPanel'; // <-- Remove import
 // import AudioControls from '../AudioControls'; // <-- Remove import
@@ -72,29 +72,28 @@ interface AppUIProps {
 // === 新增：物理燈條亮度控制 bar 組件 ===
 function PhysicalLightBarPanel({ visible, onClose }: { visible: boolean, onClose: () => void }) {
   const [value, setValue] = useState(32767);
-  const wsRef = useRef<WebSocket | null>(null);
 
   useEffect(() => {
     if (!visible) return;
-    const ws = new window.WebSocket('ws://localhost:8000/api/physical-light/ws/brightness');
-    wsRef.current = ws;
+    // 關閉面板時將燈光關掉
     return () => {
-      try {
-        if (ws.readyState === 1) {
-          ws.send(JSON.stringify({ brightness: 0 }));
-        }
-      } catch (e) {
-        console.warn('[PhysicalLightBarPanel] Failed to send off before close:', e);
-      }
-      ws.close();
+      fetch('http://localhost:8000/api/physical-light/set-brightness', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ brightness: 0 })
+      }).catch(e => console.warn('[PhysicalLightBarPanel] Failed to turn off light:', e));
     };
   }, [visible]);
 
   useEffect(() => {
-    if (wsRef.current && wsRef.current.readyState === 1) {
-      wsRef.current.send(JSON.stringify({ brightness: value }));
+    if (visible) {
+      fetch('http://localhost:8000/api/physical-light/set-brightness', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ brightness: value })
+      }).catch(e => console.warn('[PhysicalLightBarPanel] Failed to set brightness:', e));
     }
-  }, [value]);
+  }, [value, visible]);
 
   if (!visible) return null;
   return (

--- a/prototype/frontend/src/services/AudioService.ts
+++ b/prototype/frontend/src/services/AudioService.ts
@@ -25,24 +25,7 @@ class AudioService {
   private animationFrameId: number | null = null;
   private mouthAnimationIntervalId: number | null = null;
   private modelService: ModelService;
-  // === 新增：物理燈光 WebSocket 連線 ===
-  private lightWs: WebSocket | null = null;
-
-  // === 新增：確保燈光 WebSocket 連線 ===
-  private ensureLightWs(): void {
-    if (!this.lightWs || this.lightWs.readyState === 3) { // 只在沒有連線或已關閉時重新連線
-      try {
-        console.log('[AudioService] Creating new light WebSocket connection...');
-        this.lightWs = new window.WebSocket('ws://localhost:8000/api/physical-light/ws/brightness');
-        this.lightWs.onopen = () => console.log('[AudioService] Light WebSocket connected');
-        this.lightWs.onerror = (error) => console.error('[AudioService] Light WebSocket error:', error);
-        this.lightWs.onclose = () => console.log('[AudioService] Light WebSocket closed');
-      } catch (error) {
-        console.warn('[AudioService] Failed to connect to light WebSocket:', error);
-      }
-    }
-  }
-  // === 新增結束 ===
+  // 物理燈光控制改為在會話層級處理，移除本地 WebSocket 邏輯
 
   public updateTtsVolume(volume: number): void {
     if (this.playbackAudio) {
@@ -471,18 +454,6 @@ class AudioService {
       useStore.getState().setAudioLipsyncTarget('jawOpen', 0); // <-- 使用新 Action
       logger.debug('Stopped playback audio analysis loop and reset jawOpen via setAudioLipsyncTarget.', LogCategory.AUDIO);
     }
-    // 新增：在分析停止時，嘗試將燈光設 0 並關閉 WS，避免殘留
-    try {
-      if (this.lightWs && this.lightWs.readyState === 1) {
-        this.lightWs.send(JSON.stringify({ brightness: 0 }));
-      }
-      if (this.lightWs) {
-        this.lightWs.close();
-        this.lightWs = null;
-      }
-    } catch (e) {
-      console.warn('[AudioService] Failed to shutdown light WS gracefully:', e);
-    }
   }
   // --- 新增結束 ---
 
@@ -514,18 +485,6 @@ class AudioService {
     // useStore.getState().updateMorphTarget('jawOpen', jawOpenValue);
     useStore.getState().setAudioLipsyncTarget('jawOpen', jawOpenValue); // <-- 使用新 Action
     useStore.getState().setAudioAverageVolume(rms); // <-- 新增：設定平均音量
-    
-    // === 新增：同步燈光控制 ===
-    this.ensureLightWs();
-    if (this.lightWs && this.lightWs.readyState === 1) {
-      // rms 0~1 映射到 0~65535，增加靈敏度
-      const brightness = Math.round(Math.max(0, Math.min(1, rms * 10)) * 65535);
-      console.log(`[AudioService] RMS: ${rms.toFixed(4)}, Brightness: ${brightness}, WebSocket ready: ${this.lightWs.readyState === 1}`);
-      this.lightWs.send(JSON.stringify({ brightness }));
-    } else {
-      console.warn(`[AudioService] Light WebSocket not ready. State: ${this.lightWs?.readyState || 'null'}`);
-    }
-    // === 新增結束 ===
     
     // 移除之前的調試日誌
     // logger.debug(`[AnalyseFrame] RMS: ${rms.toFixed(3)}, jawOpen: ${jawOpenValue.toFixed(3)}`, LogCategory.AUDIO);

--- a/prototype/frontend/src/services/RealtimeVoiceService.ts
+++ b/prototype/frontend/src/services/RealtimeVoiceService.ts
@@ -7,8 +7,6 @@ const WS_URL = `ws://${window.location.hostname}:8000/api/real-time/ws`;
 // 專門用於實時音頻播放的類
 class RealtimeAudioPlayer {
   private audioContext: AudioContext | null = null
-  // === 新增：物理燈光 WebSocket 連線 ===
-  private lightWs: WebSocket | null = null;
   private analyser: AnalyserNode | null = null;
   private gainNode: GainNode | null = null;
   private analysisFrameId: number | null = null;
@@ -106,21 +104,7 @@ class RealtimeAudioPlayer {
     console.log(`[RealtimeAudioPlayer] Playing audio chunk: ${audioBuffer.duration.toFixed(3)}s`);
   }
 
-  // === 新增：確保燈光 WebSocket 連線 ===
-  private ensureLightWs(): void {
-    if (!this.lightWs || this.lightWs.readyState === 3) { // 只在沒有連線或已關閉時重新連線
-      try {
-        console.log('[RealtimeAudioPlayer] Creating new light WebSocket connection...');
-        this.lightWs = new window.WebSocket('ws://localhost:8000/api/physical-light/ws/brightness');
-        this.lightWs.onopen = () => console.log('[RealtimeAudioPlayer] Light WebSocket connected');
-        this.lightWs.onerror = (error) => console.error('[RealtimeAudioPlayer] Light WebSocket error:', error);
-        this.lightWs.onclose = () => console.log('[RealtimeAudioPlayer] Light WebSocket closed');
-      } catch (error) {
-        console.warn('[RealtimeAudioPlayer] Failed to connect to light WebSocket:', error);
-      }
-    }
-  }
-  // === 新增結束 ===
+  // (燈光控制已改為在對話開始/結束時透過 HTTP 控制，移除 WS 連線)
 
   private startAudioAnalysis() {
     if (!this.analyser) return;
@@ -153,15 +137,6 @@ class RealtimeAudioPlayer {
       useStore.getState().setAudioLipsyncTarget('jawOpen', jawOpenValue);
       useStore.getState().setAudioAverageVolume(rms);
       
-      // === 新增：同步燈光控制 ===
-      this.ensureLightWs();
-      if (this.lightWs && this.lightWs.readyState === 1) {
-        // rms 0~1 映射到 0~65535，增加靈敏度
-        const brightness = Math.round(Math.max(0, Math.min(1, rms * 10)) * 65535);
-        this.lightWs.send(JSON.stringify({ brightness }));
-      }
-      // === 新增結束 ===
-      
       this.analysisFrameId = requestAnimationFrame(analyze);
     };
     
@@ -177,18 +152,6 @@ class RealtimeAudioPlayer {
     // 重置嘴型
     useStore.getState().setAudioLipsyncTarget('jawOpen', 0);
 
-    // 新增：在實時播放分析停止時，也將燈光關到 0 並關閉 WS，避免持續輸入
-    try {
-      if (this.lightWs && this.lightWs.readyState === 1) {
-        this.lightWs.send(JSON.stringify({ brightness: 0 }));
-      }
-      if (this.lightWs) {
-        this.lightWs.close();
-        this.lightWs = null;
-      }
-    } catch (e) {
-      console.warn('[RealtimeAudioPlayer] Failed to shutdown light WS gracefully:', e);
-    }
   }
 
   stopPlayback() {
@@ -246,18 +209,6 @@ class RealtimeAudioPlayer {
     this.analyser = null;
     this.gainNode = null;
 
-    // 確保清理燈光 WS
-    try {
-      if (this.lightWs && this.lightWs.readyState === 1) {
-        this.lightWs.send(JSON.stringify({ brightness: 0 }));
-      }
-      if (this.lightWs) {
-        this.lightWs.close();
-        this.lightWs = null;
-      }
-    } catch (e) {
-      console.warn('[RealtimeAudioPlayer] Failed to cleanup light WS:', e);
-    }
   }
 
   // 提供公開方法讓外部也能調用立即停止
@@ -345,6 +296,13 @@ export function useRealtimeVoice() {
       wsRef.current.close();
       wsRef.current = null;
     }
+
+    // 確保會話結束時關閉物理燈光
+    fetch('http://localhost:8000/api/physical-light/set-brightness', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ brightness: 0 })
+    }).catch(err => console.warn('[RealtimeVoice] Failed to ensure light off:', err));
 
     setStreaming(false);
     setError(null);
@@ -442,9 +400,16 @@ export function useRealtimeVoice() {
       ws.onopen = () => {
         clearTimeout(connectionTimeout);
         console.log('[RealtimeVoice] WebSocket connected successfully!');
-        
+
         // 清空之前的文字內容
         useStore.getState().setSpeechText('');
+
+        // 會話啟動時開啟物理燈光
+        fetch('http://localhost:8000/api/physical-light/set-brightness', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ brightness: 65535 })
+        }).catch(err => console.warn('[RealtimeVoice] Failed to turn on light:', err));
         
         try {
           // 創建音頻處理鏈
@@ -500,8 +465,15 @@ export function useRealtimeVoice() {
       ws.onclose = (event) => {
         clearTimeout(connectionTimeout);
         console.log(`[RealtimeVoice] WebSocket closed: code=${event.code}, reason=${event.reason}`);
-        
+
         setStreaming(false);
+
+        // 會話結束時關閉物理燈光
+        fetch('http://localhost:8000/api/physical-light/set-brightness', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ brightness: 0 })
+        }).catch(err => console.warn('[RealtimeVoice] Failed to turn off light:', err));
       };
       
       ws.onmessage = async (event) => {


### PR DESCRIPTION
## Summary
- drop physical-light brightness websocket API and toggle
- manage light power when realtime conversation websocket opens/closes
- replace frontend light websocket usage with simple HTTP calls

## Testing
- `PYENV_VERSION=3.10.17 pytest` *(fails: ModuleNotFoundError: No module named 'google')*
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e192005d083218e0a8514671224d0