### PR TITLE
feat: enlarge centered pre-start countdown

### DIFF
--- a/prototype/frontend/src/App.tsx
+++ b/prototype/frontend/src/App.tsx
@@ -124,6 +124,10 @@ function App() {
   const isSideButtonsVisible = useStore((state) => state.isSideButtonsVisible);
   const toggleSideButtons = useStore((state) => state.toggleSideButtons);
   // <--- 結束 --->
+
+  // 即時排程狀態
+  const scheduleEnabled = useStore(state => state.scheduleEnabled);
+  const realtimeCurrentlyActive = useStore(state => state.realtimeCurrentlyActive);
   
   // 使用音頻服務
   const { 
@@ -735,10 +739,16 @@ function App() {
           />
         </div>
         
-        {/* 即時對話狀態指示器 - 移到右下角，只在排程啟用且面板未開啟時顯示 */}
-        {useStore(state => state.scheduleEnabled) && !isRealtimeSchedulePanelVisible && (
-          <div className="fixed top-4 left-4 z-50">
-            <RealtimeStatusIndicator />
+        {/* 即時對話狀態指示器 - 排程啟用且面板未開啟時顯示 */}
+        {scheduleEnabled && !isRealtimeSchedulePanelVisible && (
+          <div
+            className={
+              realtimeCurrentlyActive
+                ? 'fixed top-4 left-4 z-50'
+                : 'pointer-events-none fixed inset-0 flex items-center justify-center z-50'
+            }
+          >
+            <RealtimeStatusIndicator className={realtimeCurrentlyActive ? '' : 'text-2xl min-w-[360px]'} />
           </div>
         )}
         

--- a/prototype/frontend/src/components/RealtimeStatusIndicator.tsx
+++ b/prototype/frontend/src/components/RealtimeStatusIndicator.tsx
@@ -5,7 +5,7 @@ import { useStore } from '../store';
  * 終端機風格的即時對話狀態指示器
  * 顯示在左上角，排程面板收起來時顯示
  */
-export function RealtimeStatusIndicator() {
+export function RealtimeStatusIndicator({ className = '' }: { className?: string }) {
   // 不需要在這裡調用 useRealtimeScheduler，App.tsx 中已經調用了
 
   const realtimeCurrentlyActive = useStore(state => state.realtimeCurrentlyActive);
@@ -60,7 +60,9 @@ export function RealtimeStatusIndicator() {
   const isOnline = realtimeCurrentlyActive;
 
   return (
-    <div className={`font-mono text-sm select-none ${terminal.bgColor} ${terminal.borderColor} border-2 rounded-md shadow-lg backdrop-blur-sm bg-opacity-95 min-w-[280px]`}>
+    <div
+      className={`font-mono select-none ${terminal.bgColor} ${terminal.borderColor} border-2 rounded-md shadow-lg backdrop-blur-sm bg-opacity-95 min-w-[280px] text-sm ${className}`}
+    >
       {/* Terminal Header */}
       <div className="px-3 py-1 border-b border-gray-700 flex items-center justify-between">
         <div className="flex items-center space-x-2">


### PR DESCRIPTION
## Summary
- center upcoming realtime countdown
- enlarge terminal-style indicator when realtime is inactive
- allow component style overrides via className prop

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm run lint` *(fails: 191 errors, 22 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689e22bd2c74832185af521f5c4d50e7