### PR TITLE
chore(scripts): add repair script for frontend/backend restart

### DIFF
--- a/repair_frontend_backend.sh
+++ b/repair_frontend_backend.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+FRONTEND_DIR="$SCRIPT_DIR/prototype/frontend"
+BACKEND_DIR="$SCRIPT_DIR/prototype/backend"
+
+echo "快速重啟前後端服務..."
+
+echo "正在關閉後端服務..."
+pkill -f "uvicorn main:app"
+if [ $? -eq 0 ]; then
+    echo "後端服務已成功終止。"
+else
+    echo "未找到後端服務程序或終止失敗。"
+fi
+
+echo "正在關閉前端開發伺服器..."
+pkill -f "vite"
+if [ $? -eq 0 ]; then
+    echo "前端開發伺服器已成功終止。"
+else
+    echo "未找到前端開發伺服器程序或終止失敗。"
+fi
+
+sleep 2
+
+echo "正在重新啟動後端..."
+osascript <<EOF2
+tell application "Terminal"
+    activate
+    do script "cd '$BACKEND_DIR' && ./run.sh"
+    delay 0.3
+    try
+        set custom title of selected tab of front window to "BACKEND"
+    end try
+end tell
+EOF2
+
+sleep 2
+
+echo "正在重新啟動前端..."
+osascript <<EOF3
+tell application "Terminal"
+    activate
+    do script "cd '$FRONTEND_DIR' && npm run dev"
+    delay 0.3
+    try
+        set custom title of selected tab of front window to "FRONTEND"
+    end try
+end tell
+EOF3
+
+echo "前後端已重新啟動完成。"


### PR DESCRIPTION
## Summary
- add `repair_frontend_backend.sh` to quickly kill and restart frontend and backend services without restarting other apps

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install react-scripts` *(fails: 403 Forbidden)*
- `pytest` *(fails: pyenv version 3.10.14 not installed)*
- `pyenv install 3.10.14` *(fails: 403 downloading source)*
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e2b3c99808321889656c480763fb4