### PR TITLE
feat: add display text panel and API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Space Live Project 是一個互動藝術裝置，模擬一名被困於太空艙�
 - **攝影機控制系統**：支援預設位置、平滑轉換與即時角度調整
 - **場景管理**：動態場景切換與 3D 環境控制
 - **圖片生成**：整合 Gemini 圖片生成 API，支援位置與大小控制
+- **文字顯示面板**：透過 `/api/display_text` 端點取得文字並在前端專用面板呈現
 
 ## 快速開始
 
@@ -119,11 +120,11 @@ flowchart TD
     Backend -->|記憶檢索| ChromaDB[(ChromaDB)]
     Backend -->|語音服務| GoogleCloud[Google Cloud APIs]
     Backend -->|資料儲存| PostgreSQL[(PostgreSQL)]
-    
+
     Frontend --> ThreeJS[Three.js 3D 渲染]
     Frontend --> Audio[Web Audio API]
     Frontend --> State[Zustand 狀態管理]
-    
+
     Backend --> LangGraph[LangGraph 工作流程]
     Backend --> Memory[記憶系統]
     Backend --> Murmur[自言自語服務]
@@ -189,15 +190,15 @@ space_live_project/
 
 ### 主要 API 分類
 
-| 分類 | 端點數量 | 主要功能 |
-|------|---------|---------|
-| **健康檢查** | 1 | 服務狀態監控 |
-| **語音處理** | 2 | STT/TTS 語音轉換 |
-| **控制指令** | 15+ | 訊息發送、攝影機控制、動畫控制、場景管理 |
-| **圖片生成** | 1 | AI 圖片生成與顯示控制 |
-| **監控系統** | 3 | 系統狀態監控與管理 |
-| **WebSocket** | 1 | 即時雙向通訊 |
-| **靜態檔案** | 6 | 音訊、圖片、歌曲檔案服務 |
+| 分類          | 端點數量 | 主要功能                                 |
+| ------------- | -------- | ---------------------------------------- |
+| **健康檢查**  | 1        | 服務狀態監控                             |
+| **語音處理**  | 2        | STT/TTS 語音轉換                         |
+| **控制指令**  | 15+      | 訊息發送、攝影機控制、動畫控制、場景管理 |
+| **圖片生成**  | 1        | AI 圖片生成與顯示控制                    |
+| **監控系統**  | 3        | 系統狀態監控與管理                       |
+| **WebSocket** | 1        | 即時雙向通訊                             |
+| **靜態檔案**  | 6        | 音訊、圖片、歌曲檔案服務                 |
 
 ## Runtime Monitoring
 

--- a/prototype/backend/api/__init__.py
+++ b/prototype/backend/api/__init__.py
@@ -11,15 +11,16 @@ from admin import setup_admin
 from .base import create_app
 from .endpoints import (
     control,
+    display_text,
     health,
     image_generation,
     monitors,
+    news,
     perception,
     realtime_conversation,
     speech,
-    websocket,
-    news,
     web_search,
+    websocket,
 )
 from .middleware.cors import setup_cors
 
@@ -56,6 +57,7 @@ def init_app() -> FastAPI:
     app.include_router(realtime_conversation.router, prefix="/api", tags=["realtime"])
     app.include_router(news.router, prefix="/api/news", tags=["news"])
     app.include_router(web_search.router, prefix="/api", tags=["search"])
+    app.include_router(display_text.router, prefix="/api", tags=["display"])
 
     # 創建音頻目錄（如果不存在）
     audio_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "audio")
@@ -72,9 +74,7 @@ def init_app() -> FastAPI:
     os.makedirs(images_dir, exist_ok=True)
 
     # Create selfies directory
-    selfies_dir = os.path.join(
-        os.path.dirname(os.path.dirname(__file__)), "selfies"
-    )
+    selfies_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "selfies")
     os.makedirs(selfies_dir, exist_ok=True)
 
     # 確保音頻目錄有正確的權限

--- a/prototype/backend/api/endpoints/display_text.py
+++ b/prototype/backend/api/endpoints/display_text.py
@@ -1,0 +1,32 @@
+"""Simple endpoint for storing and retrieving display text."""
+
+from typing import Dict
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+
+class TextPayload(BaseModel):
+    """Request/response model for text content."""
+
+    text: str = ""
+
+
+router = APIRouter()
+
+_text_store = TextPayload()
+
+
+@router.get("/display_text", response_model=TextPayload)
+async def get_display_text() -> TextPayload:
+    """Return the currently stored text."""
+
+    return _text_store
+
+
+@router.post("/display_text")
+async def set_display_text(payload: TextPayload) -> Dict[str, bool]:
+    """Update the stored text."""
+
+    _text_store.text = payload.text
+    return {"success": True}

--- a/prototype/backend/tests/test_display_text.py
+++ b/prototype/backend/tests/test_display_text.py
@@ -1,0 +1,19 @@
+"""Tests for display_text endpoint."""
+
+from fastapi.testclient import TestClient
+
+from api import init_app
+
+client = TestClient(init_app())
+
+
+def test_display_text_round_trip() -> None:
+    """Ensure text can be set and retrieved."""
+
+    resp = client.post("/api/display_text", json={"text": "Hello"})
+    assert resp.status_code == 200
+    assert resp.json() == {"success": True}
+
+    resp = client.get("/api/display_text")
+    assert resp.status_code == 200
+    assert resp.json() == {"text": "Hello"}

--- a/prototype/frontend/src/App.tsx
+++ b/prototype/frontend/src/App.tsx
@@ -1,51 +1,55 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react'
-import './App.css'
+import React, { useState, useCallback, useEffect, useRef } from "react";
+import "./App.css";
 
 // 引入拆分出的組件
-import SceneContainer from './components/SceneContainer'
-import AppUI from './components/layout/AppUI'
-import ModelDebugger from './components/ModelDebugger'
-import ModelAnalyzerTool from './components/ModelAnalyzerTool'
-import ErrorBoundary from './components/ErrorBoundary'
-import { ToastContainer } from './components/Toast'
-import FloatingChatWindow from './components/FloatingChatWindow'
-import ImageOverlay from './components/ImageOverlay'
-import SettingsPanel from './components/SettingsPanel'
-import BackgroundSoundSystem from './components/BackgroundSoundSystem'
-import DirectorMonitorHUD from './components/DirectorMonitorHUD'
-import SubtitlesOverlay from './components/SubtitlesOverlay'
-import RoomControlPanel from './components/RoomControlPanel'
-import { CharacterControlPanel } from './components/CharacterControlPanel'
-import EnvironmentControlPanel from './components/EnvironmentControlPanel'
-import { RealtimeSchedulePanel } from './components/RealtimeSchedulePanel'
-import { RealtimeStatusIndicator, RealtimeStatusBadge } from './components/RealtimeStatusIndicator'
-import { usePerformanceMetrics } from './hooks/usePerformanceMetrics'
-import { useRealtimeScheduler } from './hooks/useRealtimeScheduler'
+import SceneContainer from "./components/SceneContainer";
+import AppUI from "./components/layout/AppUI";
+import ModelDebugger from "./components/ModelDebugger";
+import ModelAnalyzerTool from "./components/ModelAnalyzerTool";
+import ErrorBoundary from "./components/ErrorBoundary";
+import { ToastContainer } from "./components/Toast";
+import FloatingChatWindow from "./components/FloatingChatWindow";
+import ImageOverlay from "./components/ImageOverlay";
+import SettingsPanel from "./components/SettingsPanel";
+import BackgroundSoundSystem from "./components/BackgroundSoundSystem";
+import DirectorMonitorHUD from "./components/DirectorMonitorHUD";
+import SubtitlesOverlay from "./components/SubtitlesOverlay";
+import RoomControlPanel from "./components/RoomControlPanel";
+import { CharacterControlPanel } from "./components/CharacterControlPanel";
+import EnvironmentControlPanel from "./components/EnvironmentControlPanel";
+import { RealtimeSchedulePanel } from "./components/RealtimeSchedulePanel";
+import TextDisplayPanel from "./components/TextDisplayPanel";
+import {
+  RealtimeStatusIndicator,
+  RealtimeStatusBadge,
+} from "./components/RealtimeStatusIndicator";
+import { usePerformanceMetrics } from "./hooks/usePerformanceMetrics";
+import { useRealtimeScheduler } from "./hooks/useRealtimeScheduler";
 
 // 引入服務
-import { 
-  useWebSocket, 
-  useAudioService, 
+import {
+  useWebSocket,
+  useAudioService,
   useHeadService,
   useChatService,
   useBodyService,
-  useCharacterService
-} from './services'
-import { useRealtimeVoice } from './services'
+  useCharacterService,
+} from "./services";
+import { useRealtimeVoice } from "./services";
 
 // 引入 API 函數
-import { speechToText, processSpeechAudio } from './services/api';
+import { speechToText, processSpeechAudio } from "./services/api";
 
 // 引入 AudioService
-import AudioService from './services/AudioService';
+import AudioService from "./services/AudioService";
 // 引入 MessageType
-import { type MessageType } from './services/ChatService';
+import { type MessageType } from "./services/ChatService";
 
 // 引入 Zustand Store
-import { useStore } from './store'
-import logger, { LogCategory } from './utils/LogManager'
-import { toast } from 'react-hot-toast'
-import { Formation } from './store/slices/danceSlice';
+import { useStore } from "./store";
+import logger, { LogCategory } from "./utils/LogManager";
+import { toast } from "react-hot-toast";
+import { Formation } from "./store/slices/danceSlice";
 
 // --- 引入模型設定 ---
 // import { AVAILABLE_MODELS } from './config/modelConfig';
@@ -89,36 +93,59 @@ function App() {
   // 從 Zustand Store 獲取 WebSocket 連接狀態
   const wsConnected = useStore((state) => state.isConnected);
   // 從 Zustand Store 獲取最後的 WebSocket 訊息
-  const lastJsonMessage = useStore((state) => state.lastJsonMessage) as BackendMessage | null; // Add type assertion
-  
+  const lastJsonMessage = useStore(
+    (state) => state.lastJsonMessage,
+  ) as BackendMessage | null; // Add type assertion
+
   // 從 Zustand Store 獲取聊天視窗狀態和操作
   const isChatWindowVisible = useStore((state) => state.isChatWindowVisible);
   const toggleChatWindow = useStore((state) => state.toggleChatWindow);
-  
+
   // <--- 從 Zustand Store 獲取設定面板狀態和操作 --->
-  const isSettingsPanelVisible = useStore((state) => state.isSettingsPanelVisible);
+  const isSettingsPanelVisible = useStore(
+    (state) => state.isSettingsPanelVisible,
+  );
   const toggleSettingsPanel = useStore((state) => state.toggleSettingsPanel);
   // <--- 結束 --->
-  
+
   // --- 從 Zustand Store 獲取舞團控制 actions ---
   const setFormation = useStore((state) => state.setFormation);
   const setDancerCount = useStore((state) => state.setDancerCount);
-  const setDanceGroupPosition = useStore((state) => state.setDanceGroupPosition);
+  const setDanceGroupPosition = useStore(
+    (state) => state.setDanceGroupPosition,
+  );
   const setDanceGroupScale = useStore((state) => state.setDanceGroupScale);
-  
+
   // <--- 從 Zustand Store 獲取角色控制面板狀態和操作 --->
-  const isCharacterControlPanelVisible = useStore((state) => state.isCharacterControlPanelVisible);
-  const toggleCharacterControlPanel = useStore((state) => state.toggleCharacterControlPanel);
+  const isCharacterControlPanelVisible = useStore(
+    (state) => state.isCharacterControlPanelVisible,
+  );
+  const toggleCharacterControlPanel = useStore(
+    (state) => state.toggleCharacterControlPanel,
+  );
   // <--- 結束 --->
-  
+
   // <--- 從 Zustand Store 獲取環境光照控制面板狀態和操作 --->
-  const isEnvironmentControlPanelVisible = useStore((state) => state.isEnvironmentControlPanelVisible);
-  const toggleEnvironmentControlPanel = useStore((state) => state.toggleEnvironmentControlPanel);
+  const isEnvironmentControlPanelVisible = useStore(
+    (state) => state.isEnvironmentControlPanelVisible,
+  );
+  const toggleEnvironmentControlPanel = useStore(
+    (state) => state.toggleEnvironmentControlPanel,
+  );
   // <--- 結束 --->
-  
+
   // <--- 從 Zustand Store 獲取排程控制面板狀態和操作 --->
-  const isRealtimeSchedulePanelVisible = useStore((state) => state.isRealtimeSchedulePanelVisible);
-  const toggleRealtimeSchedulePanel = useStore((state) => state.toggleRealtimeSchedulePanel);
+  const isRealtimeSchedulePanelVisible = useStore(
+    (state) => state.isRealtimeSchedulePanelVisible,
+  );
+  const toggleRealtimeSchedulePanel = useStore(
+    (state) => state.toggleRealtimeSchedulePanel,
+  );
+  // <--- 結束 --->
+
+  // <--- 從 Zustand Store 獲取文字顯示面板狀態和操作 --->
+  const isTextPanelVisible = useStore((state) => state.isTextPanelVisible);
+  const toggleTextPanel = useStore((state) => state.toggleTextPanel);
   // <--- 結束 --->
 
   // <--- 從 Zustand Store 獲取右側按鈕顯示狀態和操作 --->
@@ -127,18 +154,20 @@ function App() {
   // <--- 結束 --->
 
   // 即時排程狀態
-  const scheduleEnabled = useStore(state => state.scheduleEnabled);
-  const realtimeCurrentlyActive = useStore(state => state.realtimeCurrentlyActive);
-  
+  const scheduleEnabled = useStore((state) => state.scheduleEnabled);
+  const realtimeCurrentlyActive = useStore(
+    (state) => state.realtimeCurrentlyActive,
+  );
+
   // 使用音頻服務
-  const { 
-    isRecording, 
+  const {
+    isRecording,
     isSpeaking,
     isProcessing: audioProcessing,
-    micPermission, 
-    startRecording, 
-    stopRecording, 
-    playAudio
+    micPermission,
+    startRecording,
+    stopRecording,
+    playAudio,
   } = useAudioService();
 
   const {
@@ -155,37 +184,42 @@ function App() {
   useEffect(() => {
     // 檢查是否應該啟用自動初始化（通過 URL 參數或簡化條件）
     const urlParams = new URLSearchParams(window.location.search);
-    const autoStart = urlParams.get('autostart') === 'true' || 
-                      window.location.hostname !== 'localhost'; // 非本地環境下預設啟用
-    
+    const autoStart =
+      urlParams.get("autostart") === "true" ||
+      window.location.hostname !== "localhost"; // 非本地環境下預設啟用
+
     if (!autoStart) {
-      console.log('[App] Auto-start disabled, skipping happy path initialization');
+      console.log(
+        "[App] Auto-start disabled, skipping happy path initialization",
+      );
       return;
     }
 
     // 頁面載入後 3 秒自動啟用排程模式並隱藏按鈕
     const initTimer = setTimeout(() => {
-      console.log('[App] Auto-initializing happy path...');
-      
+      console.log("[App] Auto-initializing happy path...");
+
       // 1. 啟用排程模式
       useStore.getState().setScheduleEnabled(true);
-      console.log('[App] ✅ Schedule enabled');
-      
+      console.log("[App] ✅ Schedule enabled");
+
       // 2. 隱藏右側按鈕（只有在顯示時才隱藏）
       if (useStore.getState().isSideButtonsVisible) {
         useStore.getState().toggleSideButtons();
-        console.log('[App] ✅ Side buttons hidden');
+        console.log("[App] ✅ Side buttons hidden");
       }
-      
+
       // 3. 確保不是手動模式
       if (useStore.getState().isManualMode) {
         useStore.getState().disableManualMode();
-        console.log('[App] ✅ Manual mode disabled');
+        console.log("[App] ✅ Manual mode disabled");
       }
-      
+
       // 全螢幕模式由 AppleScript 腳本處理
-      
-      console.log('[App] 🚀 Happy path initialized - Schedule running with hidden UI');
+
+      console.log(
+        "[App] 🚀 Happy path initialized - Schedule running with hidden UI",
+      );
     }, 3000); // 3秒後執行
 
     return () => clearTimeout(initTimer);
@@ -195,19 +229,23 @@ function App() {
   useEffect(() => {
     console.log(`[App] RealtimeStreaming changed to: ${realtimeStreaming}`);
     const currentScheduleState = useStore.getState().realtimeCurrentlyActive;
-    
+
     // 只有在狀態真的不同時才更新，避免循環
     if (currentScheduleState !== realtimeStreaming) {
-      console.log(`[App] Syncing schedule state from ${currentScheduleState} to ${realtimeStreaming}`);
+      console.log(
+        `[App] Syncing schedule state from ${currentScheduleState} to ${realtimeStreaming}`,
+      );
       useStore.getState().setRealtimeActive(realtimeStreaming);
     }
   }, [realtimeStreaming]);
 
   const toggleRealtime = useCallback(() => {
-    console.log(`[App] Manual toggle realtime, current streaming: ${realtimeStreaming}`);
+    console.log(
+      `[App] Manual toggle realtime, current streaming: ${realtimeStreaming}`,
+    );
     // 啟用手動模式，暫停自動排程
     useStore.getState().enableManualMode();
-    
+
     if (realtimeStreaming) {
       stopRealtime();
     } else {
@@ -221,13 +259,13 @@ function App() {
     const realtimeVoiceHandler = (e: Event) => {
       const action = (e as CustomEvent<string>).detail;
       console.log(`[App] Received realtime voice control: ${action}`);
-      
+
       // 只有在非手動模式時才處理自動排程的消息
       const isManualMode = useStore.getState().isManualMode;
       if (!isManualMode) {
-        if (action === 'start') {
+        if (action === "start") {
           startRealtime();
-        } else if (action === 'stop') {
+        } else if (action === "stop") {
           stopRealtime();
         }
       }
@@ -235,44 +273,48 @@ function App() {
 
     // 監聽手動控制事件
     const manualControlHandler = (e: Event) => {
-      const { action, source } = (e as CustomEvent<{action: string, source: string}>).detail;
-      console.log(`[App] Received manual realtime control: ${action} from ${source}`);
-      
-      if (action === 'start') {
+      const { action, source } = (
+        e as CustomEvent<{ action: string; source: string }>
+      ).detail;
+      console.log(
+        `[App] Received manual realtime control: ${action} from ${source}`,
+      );
+
+      if (action === "start") {
         startRealtime();
-      } else if (action === 'stop') {
+      } else if (action === "stop") {
         stopRealtime();
       }
     };
 
-    window.addEventListener('realtimeVoiceControl', realtimeVoiceHandler);
-    window.addEventListener('manualRealtimeControl', manualControlHandler);
+    window.addEventListener("realtimeVoiceControl", realtimeVoiceHandler);
+    window.addEventListener("manualRealtimeControl", manualControlHandler);
 
     const onKey = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
-      
+
       // 避免在輸入框中觸發快捷鍵
-      if (target.tagName === 'INPUT' || target.isContentEditable) {
+      if (target.tagName === "INPUT" || target.isContentEditable) {
         return;
       }
-      
-      if (e.code === 'Space' && !e.repeat) {
+
+      if (e.code === "Space" && !e.repeat) {
         e.preventDefault();
         toggleRealtime();
-      } else if (e.code === 'KeyC' && !e.repeat) {
+      } else if (e.code === "KeyC" && !e.repeat) {
         e.preventDefault();
-        console.log('[App] C key pressed - toggling side buttons');
+        console.log("[App] C key pressed - toggling side buttons");
         toggleSideButtons();
       }
     };
-    window.addEventListener('keydown', onKey);
+    window.addEventListener("keydown", onKey);
     return () => {
-      window.removeEventListener('realtimeVoiceControl', realtimeVoiceHandler);
-      window.removeEventListener('manualRealtimeControl', manualControlHandler);
-      window.removeEventListener('keydown', onKey);
+      window.removeEventListener("realtimeVoiceControl", realtimeVoiceHandler);
+      window.removeEventListener("manualRealtimeControl", manualControlHandler);
+      window.removeEventListener("keydown", onKey);
     };
   }, [toggleRealtime, toggleSideButtons]);
-  
+
   // --- 使用頭部服務 (替換 useModelService) ---
   const {
     headModelLoaded,
@@ -291,67 +333,75 @@ function App() {
     updateMorphTargetInfluence,
     resetAllMorphTargets,
     applyPresetExpression,
-    switchHeadModel
+    switchHeadModel,
   } = useHeadService();
-  // --- 結束 --- 
-  
-  // --- 使用身體服務 ---
-  const {
-    availableAnimations,
-    currentAnimation,
-    selectAnimation
-  } = useBodyService();
   // --- 結束 ---
-  
+
+  // --- 使用身體服務 ---
+  const { availableAnimations, currentAnimation, selectAnimation } =
+    useBodyService();
+  // --- 結束 ---
+
   // --- 使用角色服務 ---
   useCharacterService(); // 初始化角色服務
   // --- 結束 ---
-  
+
   // 使用聊天服務
-  const {
-    messages,
-    sendMessage,
-    clearMessages
-  } = useChatService();
-  
+  const { messages, sendMessage, clearMessages } = useChatService();
+
   // 從 Zustand 直接獲取處理狀態
   const chatProcessing = useStore((state) => state.isProcessing);
-  
+
   // 從 Zustand 直接獲取情緒狀態
-  const currentEmotion = useStore((state) => state.currentEmotion.emotion || 'neutral');
-  const emotionConfidence = useStore((state) => state.currentEmotion.confidence || 0);
-  
+  const currentEmotion = useStore(
+    (state) => state.currentEmotion.emotion || "neutral",
+  );
+  const emotionConfidence = useStore(
+    (state) => state.currentEmotion.confidence || 0,
+  );
+
   // 使用本地狀態管理用戶輸入
-  const [userInput, setUserInput] = useState('');
-  
+  const [userInput, setUserInput] = useState("");
+
   // 選定的Morph Target
-  const [selectedMorphTarget, setSelectedMorphTarget] = useState<string | null>(null);
+  const [selectedMorphTarget, setSelectedMorphTarget] = useState<string | null>(
+    null,
+  );
 
   // 調試模式狀態
   const [debugMode, setDebugMode] = useState<boolean>(false);
-  
+
   // 模型分析工具狀態
   const [showModelAnalyzer, setShowModelAnalyzer] = useState<boolean>(false);
 
   // --- Zustand State and Actions ---
   const setProcessing = useStore((state) => state.setProcessing); // <-- Get action via selector
   const addChatMessage = useStore((state) => state.addMessage); // <-- Get chat message adding action. THIS IS THE CORRECT ONE.
-  // --- End Zustand --- 
+  // --- End Zustand ---
 
   // --- 從 Zustand 獲取/設置建議的動畫名稱 ---
-  const suggestedAnimationName = useStore((state) => state.suggestedAnimationName);
-  const setSuggestedAnimationName = useStore((state) => state.setSuggestedAnimationName);
+  const suggestedAnimationName = useStore(
+    (state) => state.suggestedAnimationName,
+  );
+  const setSuggestedAnimationName = useStore(
+    (state) => state.setSuggestedAnimationName,
+  );
 
   // --- 從 Zustand 獲取/設置動畫序列相關的狀態和操作 ---
   const animationSequence = useStore((state) => state.animationSequence);
   const setAnimationSequence = useStore((state) => state.setAnimationSequence);
-  const startSequencePlayback = useStore((state) => state.startSequencePlayback);
+  const startSequencePlayback = useStore(
+    (state) => state.startSequencePlayback,
+  );
   const stopSequencePlayback = useStore((state) => state.stopSequencePlayback);
 
   // 處理 WebSocket 訊息，提取並設置建議的動畫名稱到 Zustand
   useEffect(() => {
     // 使用 JSON.stringify 確保傳遞給 logger 的是字符串
-    logger.debug(`[AppWS Parse Effect] Running. lastJsonMessage: ${JSON.stringify(lastJsonMessage)}`, LogCategory.WEBSOCKET);
+    logger.debug(
+      `[AppWS Parse Effect] Running. lastJsonMessage: ${JSON.stringify(lastJsonMessage)}`,
+      LogCategory.WEBSOCKET,
+    );
     // Assert lastJsonMessage to our more comprehensive type
     const currentMessage = lastJsonMessage as BackendMessage | null;
 
@@ -360,71 +410,118 @@ function App() {
     }
 
     switch (currentMessage.type) {
-      case 'chat-message':
-        if (currentMessage.message && typeof currentMessage.message === 'object') {
-            logger.debug('[AppWS Parse Effect] Condition 2 passed: Message payload exists and is object.', LogCategory.WEBSOCKET);
-            
-            // message 負載現在符合 ChatMessagePayload 類型
-            const messagePayload = currentMessage.message;
-            
-            // 處理 bodyAnimationSequence (新增)
-            if ('bodyAnimationSequence' in messagePayload && 
-                Array.isArray(messagePayload.bodyAnimationSequence) && 
-                messagePayload.bodyAnimationSequence.length > 0) {
-                
-                logger.info(`[AppWS] Received animation sequence with ${messagePayload.bodyAnimationSequence.length} keyframes.`, LogCategory.WEBSOCKET);
-                
-                // 儲存動畫序列到 Zustand
-                setAnimationSequence(messagePayload.bodyAnimationSequence);
-                
-                // 不再處理 bodyAnimationName，因為使用序列
-                return;
+      case "chat-message":
+        if (
+          currentMessage.message &&
+          typeof currentMessage.message === "object"
+        ) {
+          logger.debug(
+            "[AppWS Parse Effect] Condition 2 passed: Message payload exists and is object.",
+            LogCategory.WEBSOCKET,
+          );
+
+          // message 負載現在符合 ChatMessagePayload 類型
+          const messagePayload = currentMessage.message;
+
+          // 處理 bodyAnimationSequence (新增)
+          if (
+            "bodyAnimationSequence" in messagePayload &&
+            Array.isArray(messagePayload.bodyAnimationSequence) &&
+            messagePayload.bodyAnimationSequence.length > 0
+          ) {
+            logger.info(
+              `[AppWS] Received animation sequence with ${messagePayload.bodyAnimationSequence.length} keyframes.`,
+              LogCategory.WEBSOCKET,
+            );
+
+            // 儲存動畫序列到 Zustand
+            setAnimationSequence(messagePayload.bodyAnimationSequence);
+
+            // 不再處理 bodyAnimationName，因為使用序列
+            return;
+          }
+
+          // 如果沒有序列，則回退到處理單一動畫名稱
+          if ("bodyAnimationName" in messagePayload) {
+            logger.debug(
+              "[AppWS Parse Effect] Condition 3 passed: bodyAnimationName key exists in payload.",
+              LogCategory.WEBSOCKET,
+            );
+            const backendAnimationName = messagePayload.bodyAnimationName;
+            logger.debug(
+              `[AppWS Parse Effect] Extracted bodyAnimationName: ${backendAnimationName}`,
+              LogCategory.WEBSOCKET,
+            );
+
+            // 檢查提取到的名稱是否為字符串 (可能為 null)
+            if (
+              typeof backendAnimationName === "string" &&
+              backendAnimationName.trim() !== ""
+            ) {
+              logger.debug(
+                "[AppWS Parse Effect] Condition 4 passed: Animation name is a non-empty string.",
+                LogCategory.WEBSOCKET,
+              );
+              // 驗證是否在可用動畫列表中 (可選但建議)
+              if (availableAnimations.includes(backendAnimationName)) {
+                logger.info(
+                  `[AppWS] Received suggested animation: ${backendAnimationName} from chat-message. Storing to Zustand...`,
+                  LogCategory.WEBSOCKET,
+                );
+                // 存儲到 Zustand
+                setSuggestedAnimationName(backendAnimationName);
+              } else {
+                logger.warn(
+                  `[AppWS] Received suggested animation "${backendAnimationName}" not in available list. Ignoring. Available: ${availableAnimations.join(", ")}`,
+                  LogCategory.WEBSOCKET,
+                );
+                // setSuggestedAnimationName(null);
+              }
+            } else if (
+              backendAnimationName === null ||
+              backendAnimationName === ""
+            ) {
+              // 如果後端明確發送 null 或空字符串
+              logger.info(
+                `[AppWS] Received null/empty suggested animation. Setting to null.`,
+                LogCategory.WEBSOCKET,
+              );
+              // 設置為 null
+              setSuggestedAnimationName(null);
+            } else {
+              logger.warn(
+                `[AppWS] Received bodyAnimationName but it's not a valid string or null: ${backendAnimationName}`,
+                LogCategory.WEBSOCKET,
+              );
             }
-            
-            // 如果沒有序列，則回退到處理單一動畫名稱
-            if ('bodyAnimationName' in messagePayload) {
-                logger.debug('[AppWS Parse Effect] Condition 3 passed: bodyAnimationName key exists in payload.', LogCategory.WEBSOCKET);
-                const backendAnimationName = messagePayload.bodyAnimationName;
-                logger.debug(`[AppWS Parse Effect] Extracted bodyAnimationName: ${backendAnimationName}`, LogCategory.WEBSOCKET);
-                
-                // 檢查提取到的名稱是否為字符串 (可能為 null)
-                if (typeof backendAnimationName === 'string' && backendAnimationName.trim() !== '') {
-                  logger.debug('[AppWS Parse Effect] Condition 4 passed: Animation name is a non-empty string.', LogCategory.WEBSOCKET);
-                  // 驗證是否在可用動畫列表中 (可選但建議)
-                  if (availableAnimations.includes(backendAnimationName)) {
-                      logger.info(`[AppWS] Received suggested animation: ${backendAnimationName} from chat-message. Storing to Zustand...`, LogCategory.WEBSOCKET);
-                      // 存儲到 Zustand
-                      setSuggestedAnimationName(backendAnimationName);
-                  } else {
-                       logger.warn(`[AppWS] Received suggested animation "${backendAnimationName}" not in available list. Ignoring. Available: ${availableAnimations.join(', ')}`, LogCategory.WEBSOCKET);
-                       // setSuggestedAnimationName(null);
-                  }
-                } else if (backendAnimationName === null || backendAnimationName === '') {
-                   // 如果後端明確發送 null 或空字符串
-                   logger.info(`[AppWS] Received null/empty suggested animation. Setting to null.`, LogCategory.WEBSOCKET);
-                   // 設置為 null
-                   setSuggestedAnimationName(null);
-                } else {
-                   logger.warn(`[AppWS] Received bodyAnimationName but it's not a valid string or null: ${backendAnimationName}`, LogCategory.WEBSOCKET);
-                }
-             } else {
-                 logger.debug('[AppWS Parse Effect] Condition 3 FAILED: bodyAnimationName key NOT in payload.', LogCategory.WEBSOCKET);
-             }
+          } else {
+            logger.debug(
+              "[AppWS Parse Effect] Condition 3 FAILED: bodyAnimationName key NOT in payload.",
+              LogCategory.WEBSOCKET,
+            );
+          }
         } else {
-             logger.debug('[AppWS Parse Effect] Condition 2 FAILED: Message payload does not exist or is not an object.', LogCategory.WEBSOCKET);
+          logger.debug(
+            "[AppWS Parse Effect] Condition 2 FAILED: Message payload does not exist or is not an object.",
+            LogCategory.WEBSOCKET,
+          );
         }
         break;
 
-      case 'dance_group_update':
+      case "dance_group_update":
         if (currentMessage.payload) {
-          logger.info('[AppWS] Received dance group update.', LogCategory.WEBSOCKET);
-          const { formation, dancerCount, position, scale } = currentMessage.payload;
+          logger.info(
+            "[AppWS] Received dance group update.",
+            LogCategory.WEBSOCKET,
+          );
+          const { formation, dancerCount, position, scale } =
+            currentMessage.payload;
           if (formation) setFormation(formation as Formation);
           if (dancerCount) setDancerCount(dancerCount);
           if (position && position.length === 3) {
-            setDanceGroupPosition('x', position[0]);
-            setDanceGroupPosition('y', position[1]);
-            setDanceGroupPosition('z', position[2]);
+            setDanceGroupPosition("x", position[0]);
+            setDanceGroupPosition("y", position[1]);
+            setDanceGroupPosition("z", position[2]);
           }
           if (scale) setDanceGroupScale(scale);
         }
@@ -432,16 +529,25 @@ function App() {
 
       // ... (other cases like 'emotionalTrajectory')
     }
-  }, [lastJsonMessage, availableAnimations, setSuggestedAnimationName, setAnimationSequence, setFormation, setDancerCount, setDanceGroupPosition, setDanceGroupScale]);
+  }, [
+    lastJsonMessage,
+    availableAnimations,
+    setSuggestedAnimationName,
+    setAnimationSequence,
+    setFormation,
+    setDancerCount,
+    setDanceGroupPosition,
+    setDanceGroupScale,
+  ]);
   // ------------------------------------
 
   // --- 同步身體動畫與語音狀態 ---
   const prevIsSpeaking = useRef<boolean>(isSpeaking);
-  const sequenceTimers = useRef<number[]>([]);  // 新增：存放定時器 ID 的數組
+  const sequenceTimers = useRef<number[]>([]); // 新增：存放定時器 ID 的數組
 
   // 新增：清理所有動畫序列定時器的函數
   const clearAllSequenceTimers = () => {
-    sequenceTimers.current.forEach(timerId => {
+    sequenceTimers.current.forEach((timerId) => {
       clearTimeout(timerId);
     });
     sequenceTimers.current = [];
@@ -452,71 +558,92 @@ function App() {
     // 監聽 isSpeaking 狀態變化
     const speakingStarted = !prevIsSpeaking.current && isSpeaking;
     const speakingStopped = prevIsSpeaking.current && !isSpeaking;
-    
-    // ---> Add logging here <--- 
-    logger.debug(`[AppSync Effect Check] isSpeaking: ${isSpeaking}, prevIsSpeaking: ${prevIsSpeaking.current}, suggestedAnimationName: ${suggestedAnimationName}, animationSequence length: ${animationSequence.length}`, LogCategory.ANIMATION);
-    // ---> End logging <--- 
+
+    // ---> Add logging here <---
+    logger.debug(
+      `[AppSync Effect Check] isSpeaking: ${isSpeaking}, prevIsSpeaking: ${prevIsSpeaking.current}, suggestedAnimationName: ${suggestedAnimationName}, animationSequence length: ${animationSequence.length}`,
+      LogCategory.ANIMATION,
+    );
+    // ---> End logging <---
 
     if (speakingStarted) {
       // 清理任何先前的定時器
       clearAllSequenceTimers();
-      
+
       // 檢查是否有動畫序列
       if (animationSequence.length > 0) {
         // 獲取音頻時長 (從 Zustand store)
         const audioDuration = useStore.getState().audioDuration;
-        
+
         if (audioDuration && audioDuration > 0) {
-          logger.info(`[AppSync] Speech started. Playing animation sequence with ${animationSequence.length} keyframes over ${audioDuration.toFixed(2)} seconds.`, LogCategory.ANIMATION);
-          
+          logger.info(
+            `[AppSync] Speech started. Playing animation sequence with ${animationSequence.length} keyframes over ${audioDuration.toFixed(2)} seconds.`,
+            LogCategory.ANIMATION,
+          );
+
           // 設置動畫序列開始
           startSequencePlayback(); // 這會立即播放第一個動畫
-          
+
           // 為每個後續的動畫設置定時器
           animationSequence.forEach((keyframe, index) => {
             // 跳過第一個動畫，因為它已經在 startSequencePlayback 中開始播放
             if (index === 0) return;
-            
+
             // 計算該動畫的絕對開始時間（毫秒）
             const startTimeMs = keyframe.proportion * audioDuration * 1000;
-            
+
             // 設置定時器
             const timerId = window.setTimeout(() => {
               // 確保仍然在播放狀態和序列播放模式
-              if (useStore.getState().isSpeaking && useStore.getState().isPlayingSequence) {
-                logger.info(`[AppSync] Playing animation ${keyframe.name} at ${startTimeMs.toFixed(0)}ms (proportion: ${keyframe.proportion})`, LogCategory.ANIMATION);
+              if (
+                useStore.getState().isSpeaking &&
+                useStore.getState().isPlayingSequence
+              ) {
+                logger.info(
+                  `[AppSync] Playing animation ${keyframe.name} at ${startTimeMs.toFixed(0)}ms (proportion: ${keyframe.proportion})`,
+                  LogCategory.ANIMATION,
+                );
                 useStore.getState().playNextInSequence(index);
               }
             }, startTimeMs);
-            
+
             // 保存定時器 ID 以供後續清除
             sequenceTimers.current.push(timerId);
           });
         } else {
-          logger.warn(`[AppSync] Cannot play animation sequence: audio duration is not available or invalid (${audioDuration})`, LogCategory.ANIMATION);
+          logger.warn(
+            `[AppSync] Cannot play animation sequence: audio duration is not available or invalid (${audioDuration})`,
+            LogCategory.ANIMATION,
+          );
           // 回退到只播放第一個動畫
           if (animationSequence[0] && animationSequence[0].name) {
             selectAnimation(animationSequence[0].name);
           } else {
             // 完全回退到單一動畫名稱處理
-            const animToPlay = suggestedAnimationName || 'Idle';
+            const animToPlay = suggestedAnimationName || "Idle";
             selectAnimation(animToPlay);
           }
         }
       } else {
         // 如果沒有序列，則使用單一動畫名稱（向後兼容）
-        const animToPlay = suggestedAnimationName || 'Idle'; // 如果 Zustand 中沒有建議，播放 Idle
-        logger.info(`[AppSync] Speech started. Playing single animation: ${animToPlay}`, LogCategory.ANIMATION);
+        const animToPlay = suggestedAnimationName || "Idle"; // 如果 Zustand 中沒有建議，播放 Idle
+        logger.info(
+          `[AppSync] Speech started. Playing single animation: ${animToPlay}`,
+          LogCategory.ANIMATION,
+        );
         selectAnimation(animToPlay);
       }
     } else if (speakingStopped) {
       // 語音停止播放，清理定時器並停止序列播放
       clearAllSequenceTimers();
-      
+
       // 停止序列播放（會切換回 Idle）
       stopSequencePlayback();
-      
-      logger.info(`[AppSync] Speech stopped. Cleared all timers and reset to Idle animation.`, LogCategory.ANIMATION);
+
+      logger.info(
+        `[AppSync] Speech stopped. Cleared all timers and reset to Idle animation.`,
+        LogCategory.ANIMATION,
+      );
     }
 
     // 更新 previous state
@@ -526,147 +653,187 @@ function App() {
     return () => {
       clearAllSequenceTimers();
     };
-
-  }, [isSpeaking, selectAnimation, suggestedAnimationName, availableAnimations, animationSequence, startSequencePlayback, stopSequencePlayback]); // 依賴項添加序列相關項
+  }, [
+    isSpeaking,
+    selectAnimation,
+    suggestedAnimationName,
+    availableAnimations,
+    animationSequence,
+    startSequencePlayback,
+    stopSequencePlayback,
+  ]); // 依賴項添加序列相關項
   // ----------------------------
 
   // === 定義錄音結束後的回調 ===
-  const handleStopRecording = useCallback(async (audioBlob: Blob | null) => {
-    if (audioBlob && wsConnected) {
-      logger.info('[App] Sending audio for processing...', LogCategory.GENERAL);
-      setProcessing(true); // Set processing before API call
-      try {
-        // Assuming processSpeechAudio returns: { success: boolean, text?: string, response?: string, audio?: string, error?: string }
-        // And does NOT currently return audio_duration.
-        const result = await processSpeechAudio(audioBlob); 
-        
-        if (result && result.success) {
-          // 1. Add user's transcribed speech if available
-          if (result.text) {
-            logger.info(`[App] STT: "${result.text}"`, LogCategory.GENERAL);
-            const userMessage: MessageType = {
-              id: `user-stt-${Date.now()}`,
-              role: 'user',
-              content: result.text,
-              timestamp: new Date().toISOString(),
-            };
-            addChatMessage(userMessage); 
-          }
+  const handleStopRecording = useCallback(
+    async (audioBlob: Blob | null) => {
+      if (audioBlob && wsConnected) {
+        logger.info(
+          "[App] Sending audio for processing...",
+          LogCategory.GENERAL,
+        );
+        setProcessing(true); // Set processing before API call
+        try {
+          // Assuming processSpeechAudio returns: { success: boolean, text?: string, response?: string, audio?: string, error?: string }
+          // And does NOT currently return audio_duration.
+          const result = await processSpeechAudio(audioBlob);
 
-          // 2. Handle bot's response (audio and/or text)
-          if (result.response) { 
-            let speechDurationForTypingEffect: number | undefined = undefined;
-            
-            // Estimate duration based on text length and presence of audio
-            if (result.audio) { // Has audio, estimate duration based on text for lip-sync like effect
-              const estimatedDuration = result.response.length * 0.18; // Approx 0.18s per char
-              speechDurationForTypingEffect = Math.max(1, estimatedDuration); // Min 1 second for some effect
-              logger.info(`[App] Estimated audio duration for typing effect: ${speechDurationForTypingEffect}s for text length ${result.response.length}`, LogCategory.GENERAL);
-            } else { // No audio, just text response, estimate based on text for a comfortable reading speed
-              const estimatedDuration = result.response.length * 0.1; // Approx 0.1s per char for reading
-              speechDurationForTypingEffect = Math.max(1, estimatedDuration); // Min 1 second
-              logger.info(`[App] Estimated reading duration for typing effect (text only): ${speechDurationForTypingEffect}s for text length ${result.response.length}`, LogCategory.GENERAL);
+          if (result && result.success) {
+            // 1. Add user's transcribed speech if available
+            if (result.text) {
+              logger.info(`[App] STT: "${result.text}"`, LogCategory.GENERAL);
+              const userMessage: MessageType = {
+                id: `user-stt-${Date.now()}`,
+                role: "user",
+                content: result.text,
+                timestamp: new Date().toISOString(),
+              };
+              addChatMessage(userMessage);
             }
 
-            const botResponseMessage: MessageType = {
-              id: `bot-resp-${Date.now()}`,
-              role: 'bot',
-              content: result.response, 
-              fullContent: result.response, 
-              isTyping: true, 
-              timestamp: new Date().toISOString(),
-              speechDuration: speechDurationForTypingEffect, 
-            };
-            addChatMessage(botResponseMessage);
+            // 2. Handle bot's response (audio and/or text)
+            if (result.response) {
+              let speechDurationForTypingEffect: number | undefined = undefined;
 
-            if (result.audio) { 
-              logger.info(`[App] Playing bot audio.`, LogCategory.GENERAL);
-              AudioService.getInstance().playAudio(`data:audio/mp3;base64,${result.audio}`);
+              // Estimate duration based on text length and presence of audio
+              if (result.audio) {
+                // Has audio, estimate duration based on text for lip-sync like effect
+                const estimatedDuration = result.response.length * 0.18; // Approx 0.18s per char
+                speechDurationForTypingEffect = Math.max(1, estimatedDuration); // Min 1 second for some effect
+                logger.info(
+                  `[App] Estimated audio duration for typing effect: ${speechDurationForTypingEffect}s for text length ${result.response.length}`,
+                  LogCategory.GENERAL,
+                );
+              } else {
+                // No audio, just text response, estimate based on text for a comfortable reading speed
+                const estimatedDuration = result.response.length * 0.1; // Approx 0.1s per char for reading
+                speechDurationForTypingEffect = Math.max(1, estimatedDuration); // Min 1 second
+                logger.info(
+                  `[App] Estimated reading duration for typing effect (text only): ${speechDurationForTypingEffect}s for text length ${result.response.length}`,
+                  LogCategory.GENERAL,
+                );
+              }
+
+              const botResponseMessage: MessageType = {
+                id: `bot-resp-${Date.now()}`,
+                role: "bot",
+                content: result.response,
+                fullContent: result.response,
+                isTyping: true,
+                timestamp: new Date().toISOString(),
+                speechDuration: speechDurationForTypingEffect,
+              };
+              addChatMessage(botResponseMessage);
+
+              if (result.audio) {
+                logger.info(`[App] Playing bot audio.`, LogCategory.GENERAL);
+                AudioService.getInstance().playAudio(
+                  `data:audio/mp3;base64,${result.audio}`,
+                );
+              }
+            }
+          } else if (result && !result.success) {
+            logger.error(
+              `[App] Audio processing failed: ${result.error}`,
+              LogCategory.GENERAL,
+            );
+            toast.error(`語音處理失敗: ${result.error || "未知錯誤"}`);
+          } else {
+            logger.warn(
+              "[App] Audio processing returned unexpected result or no audio/response.",
+              LogCategory.GENERAL,
+            );
+            // Only show toast if there's no specific error message from backend
+            if (!(result && result.error)) {
+              toast("無法處理您的語音，請再試一次。");
             }
           }
-
-        } else if (result && !result.success) {
-          logger.error(`[App] Audio processing failed: ${result.error}`, LogCategory.GENERAL);
-          toast.error(`語音處理失敗: ${result.error || '未知錯誤'}`);
-        } else {
-          logger.warn('[App] Audio processing returned unexpected result or no audio/response.', LogCategory.GENERAL);
-          // Only show toast if there's no specific error message from backend
-          if (!(result && result.error)) {
-            toast('無法處理您的語音，請再試一次。');
-          }
+        } catch (error) {
+          logger.error(
+            "[App] Audio processing API call error:",
+            LogCategory.GENERAL,
+            error,
+          );
+          toast.error(
+            `語音處理請求失敗: ${error instanceof Error ? error.message : "未知網絡錯誤"}`,
+          );
+        } finally {
+          setProcessing(false);
         }
-      } catch (error) {
-        logger.error('[App] Audio processing API call error:', LogCategory.GENERAL, error);
-        toast.error(`語音處理請求失敗: ${error instanceof Error ? error.message : '未知網絡錯誤'}`);
-      } finally {
-        setProcessing(false);
+      } else if (!wsConnected) {
+        logger.warn(
+          "[App] Recording finished, but WebSocket not connected. Cannot process audio.",
+          LogCategory.GENERAL,
+        );
+        toast.error("網絡未連接，無法處理語音。");
+      } else if (!audioBlob) {
+        logger.warn(
+          "[App] Recording finished, but audio blob is null.",
+          LogCategory.GENERAL,
+        );
+        // No toast here as this might be an intentional quick tap without speech
       }
-      
-    } else if (!wsConnected) {
-      logger.warn('[App] Recording finished, but WebSocket not connected. Cannot process audio.', LogCategory.GENERAL);
-      toast.error('網絡未連接，無法處理語音。');
-    } else if (!audioBlob) {
-      logger.warn('[App] Recording finished, but audio blob is null.', LogCategory.GENERAL);
-      // No toast here as this might be an intentional quick tap without speech
-    }
-  }, [wsConnected, setProcessing, addChatMessage]); // addChatMessage from useStore is correctly in dependencies now
+    },
+    [wsConnected, setProcessing, addChatMessage],
+  ); // addChatMessage from useStore is correctly in dependencies now
   // === 回調定義結束 ===
 
-  // 切換調試模式 
+  // 切換調試模式
   const toggleDebugMode = useCallback(() => {
-    setDebugMode(prev => !prev);
+    setDebugMode((prev) => !prev);
   }, []);
-  
+
   // 切換模型分析工具
   const toggleModelAnalyzer = () => setShowModelAnalyzer(!showModelAnalyzer);
 
   // 處理發送消息 (Enter 鍵或點擊按鈕)
   const handleSendMessage = useCallback(() => {
-    if (userInput.trim() && wsConnected) { // 確保已連接才發送
+    if (userInput.trim() && wsConnected) {
+      // 確保已連接才發送
       sendMessage(userInput); // This is from useChatService, sends text via WebSocket
-      setUserInput(''); // 清空輸入
+      setUserInput(""); // 清空輸入
     } else if (!wsConnected) {
       console.warn("嘗試發送消息但 WebSocket 未連接");
-      toast.error('網絡未連接，無法發送消息。');
+      toast.error("網絡未連接，無法發送消息。");
     }
   }, [userInput, wsConnected, sendMessage]);
 
   // 處理鍵盤事件 (Enter發送)
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
-      if (event.key === 'Enter' && !event.shiftKey) {
+      if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault();
         handleSendMessage();
         // 確保輸入框被清空
-        setTimeout(() => setUserInput(''), 50);
+        setTimeout(() => setUserInput(""), 50);
       }
     },
-    [handleSendMessage, setUserInput]
+    [handleSendMessage, setUserInput],
   );
 
   return (
     <ErrorBoundary>
       <div className="app-container">
         <BackgroundSoundSystem />
-        <SceneContainer 
+        <SceneContainer
           headModelUrl={headModelUrl}
           isHeadModelLoaded={headModelLoaded}
           showSpaceBackground={showSpaceBackground}
           modelScale={modelScale}
-          headOnly={new URLSearchParams(window.location.search).has('headonly')}
+          headOnly={new URLSearchParams(window.location.search).has("headonly")}
         />
         {/* === 刪除：燈光亮度控制 bar === */}
         {/* <LightBarControl /> */}
         {/* === 刪除結束 === */}
-        
+
         {/* 調試面板 (保持在 App 層) */}
         {debugMode && <ModelDebugger url={headModelUrl} />}
-        
+
         {/* 模型分析工具 (保持在 App 層) */}
         {showModelAnalyzer && <div>模型分析工具 (模型列表待定)</div>}
 
         {/* 渲染新的浮動聊天視窗 */}
-        <FloatingChatWindow 
+        <FloatingChatWindow
           isVisible={isChatWindowVisible}
           onClose={toggleChatWindow}
           messages={messages || []} // messages from useChatService
@@ -701,9 +868,9 @@ function App() {
           applyPresetExpression={applyPresetExpression}
           showSpaceBackground={showSpaceBackground}
           // Pass body animation props
-          availableAnimations={availableAnimations} 
-          currentAnimation={currentAnimation} 
-          selectAnimation={selectAnimation} 
+          availableAnimations={availableAnimations}
+          currentAnimation={currentAnimation}
+          selectAnimation={selectAnimation}
           // Pass emotion state for display
           currentEmotion={currentEmotion}
           emotionConfidence={emotionConfidence}
@@ -713,55 +880,75 @@ function App() {
           modelUrl={headModelUrl} // Use headModelUrl here
           toggleDebugMode={toggleDebugMode}
           toggleModelAnalyzer={toggleModelAnalyzer}
-          handleModelSwitch={() => { logger.warn('Model switching is temporarily disabled.', LogCategory.GENERAL); }} // Placeholder
+          handleModelSwitch={() => {
+            logger.warn(
+              "Model switching is temporarily disabled.",
+              LogCategory.GENERAL,
+            );
+          }} // Placeholder
         />
         {/* <--- 結束 ---> */}
-        
+
         {/* 房間控制面板 */}
-        <RoomControlPanel isVisible={useStore((state) => state.isRoomControlPanelVisible)} />
-        
+        <RoomControlPanel
+          isVisible={useStore((state) => state.isRoomControlPanelVisible)}
+        />
+
         {/* 角色控制面板 */}
-        <CharacterControlPanel 
+        <CharacterControlPanel
           isVisible={isCharacterControlPanelVisible}
           onClose={toggleCharacterControlPanel}
         />
-        
+
         {/* 環境光照控制面板 */}
-        <EnvironmentControlPanel 
+        <EnvironmentControlPanel
           isVisible={isEnvironmentControlPanelVisible}
           onClose={toggleEnvironmentControlPanel}
         />
-        
+
+        {/* 文字顯示面板 */}
+        <TextDisplayPanel
+          isVisible={isTextPanelVisible}
+          onClose={toggleTextPanel}
+        />
+
         {/* 即時對話排程控制面板 - 移到左下角 */}
         <div className="fixed bottom-4 left-4 z-50 w-80">
-          <RealtimeSchedulePanel 
+          <RealtimeSchedulePanel
             isVisible={isRealtimeSchedulePanelVisible}
             onClose={toggleRealtimeSchedulePanel}
           />
         </div>
-        
+
         {/* 即時對話狀態指示器 - 排程啟用且面板未開啟時顯示 */}
         {scheduleEnabled && !isRealtimeSchedulePanelVisible && (
           <div
             className={
               realtimeCurrentlyActive
-                ? 'fixed top-4 left-4 z-50'
-                : 'pointer-events-none fixed inset-0 flex items-center justify-center z-50'
+                ? "fixed top-4 left-4 z-50"
+                : "pointer-events-none fixed inset-0 flex items-center justify-center z-50"
             }
           >
-            <RealtimeStatusIndicator className={realtimeCurrentlyActive ? '' : 'text-2xl min-w-[360px]'} />
+            <RealtimeStatusIndicator
+              className={
+                realtimeCurrentlyActive ? "" : "text-2xl min-w-[360px]"
+              }
+            />
           </div>
         )}
-        
+
         {/* 渲染 AppUI (只傳遞必要 props) */}
         <AppUI
           wsConnected={wsConnected}
           toggleChatWindow={toggleChatWindow}
           toggleSettingsPanel={toggleSettingsPanel}
-          toggleRoomControlPanel={useStore((state) => state.toggleRoomControlPanel)}
+          toggleRoomControlPanel={useStore(
+            (state) => state.toggleRoomControlPanel,
+          )}
           toggleCharacterControlPanel={toggleCharacterControlPanel}
           toggleEnvironmentControlPanel={toggleEnvironmentControlPanel}
           toggleRealtimeSchedulePanel={toggleRealtimeSchedulePanel}
+          toggleTextPanel={toggleTextPanel}
           toggleRealtime={toggleRealtime}
           realtimeStreaming={realtimeStreaming}
           realtimeError={realtimeError}
@@ -776,7 +963,7 @@ function App() {
         <DirectorMonitorHUD />
       </div>
     </ErrorBoundary>
-  )
+  );
 }
 
 export default App;

--- a/prototype/frontend/src/components/TextDisplayPanel.tsx
+++ b/prototype/frontend/src/components/TextDisplayPanel.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from "react";
+
+import { getDisplayText } from "../services/api";
+
+interface TextDisplayPanelProps {
+  isVisible: boolean;
+  onClose: () => void;
+}
+
+const panelStyle: React.CSSProperties = {
+  position: "fixed",
+  top: "20px",
+  left: "20px",
+  background: "rgba(0, 0, 0, 0.9)",
+  border: "1px solid #555",
+  borderRadius: "8px",
+  color: "white",
+  fontFamily: "Arial, sans-serif",
+  fontSize: "14px",
+  zIndex: 1000,
+  minWidth: "260px",
+  maxWidth: "320px",
+  padding: "15px",
+};
+
+const TextDisplayPanel: React.FC<TextDisplayPanelProps> = ({
+  isVisible,
+  onClose,
+}) => {
+  const [text, setText] = useState("");
+
+  useEffect(() => {
+    if (!isVisible) return;
+    getDisplayText()
+      .then((data) => setText(data.text))
+      .catch(() => setText(""));
+  }, [isVisible]);
+
+  if (!isVisible) return null;
+
+  return (
+    <div style={panelStyle}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          marginBottom: "10px",
+        }}
+      >
+        <h3 style={{ margin: 0, fontSize: "16px" }}>文字顯示</h3>
+        <button
+          onClick={onClose}
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "white",
+            cursor: "pointer",
+          }}
+        >
+          ×
+        </button>
+      </div>
+      <div style={{ whiteSpace: "pre-wrap" }}>{text}</div>
+    </div>
+  );
+};
+
+export default TextDisplayPanel;

--- a/prototype/frontend/src/components/__tests__/TextDisplayPanel.test.tsx
+++ b/prototype/frontend/src/components/__tests__/TextDisplayPanel.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import TextDisplayPanel from "../TextDisplayPanel";
+import * as api from "../../services/api";
+
+jest.mock("../../services/api");
+
+test("renders text from API when visible", async () => {
+  (api.getDisplayText as jest.Mock).mockResolvedValue({ text: "hello world" });
+  render(<TextDisplayPanel isVisible={true} onClose={() => {}} />);
+  await waitFor(() => {
+    expect(screen.getByText("hello world")).toBeInTheDocument();
+  });
+});

--- a/prototype/frontend/src/components/layout/AppUI.tsx
+++ b/prototype/frontend/src/components/layout/AppUI.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 // import ChatInterface from '../ChatInterface'; // <-- Remove import
 // import ControlPanel from '../ControlPanel'; // <-- Remove import
 // import AudioControls from '../AudioControls'; // <-- Remove import
@@ -8,10 +8,10 @@ interface AppUIProps {
   // // Tab 狀態與切換 (REMOVED)
   // activeTab: 'control' | 'chat';
   // switchTab: (tab: 'control' | 'chat') => void;
-  
+
   // WebSocket 連接狀態
   wsConnected: boolean;
-  
+
   // 音頻控制相關 props
   // isRecording: boolean;
   // isSpeaking: boolean;
@@ -20,7 +20,7 @@ interface AppUIProps {
   // startRecording: () => Promise<void>;
   // stopRecording: () => void;
   // playAudio: (url: string) => void;
-  
+
   // 控制面板相關 props
   // modelLoaded: boolean;
   // modelScale: number;
@@ -40,7 +40,7 @@ interface AppUIProps {
   // selectAnimation: (name: string) => void;
   // applyPresetExpression: (expression: string) => Promise<boolean>;
   // showSpaceBackground: boolean;
-  
+
   // 聊天界面相關 props
   // messages: any[]; // 替換為更精確的類型
   // userInput: string;
@@ -49,7 +49,7 @@ interface AppUIProps {
   // sendMessage: () => void; // 修改這裡，對應 App.tsx 傳遞的函數
   // handleKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void; // 添加 handleKeyDown
   // clearMessages: () => void; // 添加 clearMessages
-  
+
   // 浮動聊天視窗控制
   toggleChatWindow: () => void;
   // 設定面板控制
@@ -62,6 +62,8 @@ interface AppUIProps {
   toggleEnvironmentControlPanel: () => void;
   // 排程控制面板控制
   toggleRealtimeSchedulePanel: () => void;
+  // 文字顯示面板控制
+  toggleTextPanel: () => void;
   toggleRealtime: () => void;
   realtimeStreaming: boolean;
   realtimeError: string | null;
@@ -70,34 +72,47 @@ interface AppUIProps {
 }
 
 // === 新增：物理燈條亮度控制 bar 組件 ===
-function PhysicalLightBarPanel({ visible, onClose }: { visible: boolean, onClose: () => void }) {
+function PhysicalLightBarPanel({
+  visible,
+  onClose,
+}: {
+  visible: boolean;
+  onClose: () => void;
+}) {
   const [value, setValue] = useState(32767);
 
   useEffect(() => {
     if (!visible) return;
     // 關閉面板時將燈光關掉
     return () => {
-      fetch('http://localhost:8000/api/physical-light/set-brightness', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ brightness: 0 })
-      }).catch(e => console.warn('[PhysicalLightBarPanel] Failed to turn off light:', e));
+      fetch("http://localhost:8000/api/physical-light/set-brightness", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ brightness: 0 }),
+      }).catch((e) =>
+        console.warn("[PhysicalLightBarPanel] Failed to turn off light:", e),
+      );
     };
   }, [visible]);
 
   useEffect(() => {
     if (visible) {
-      fetch('http://localhost:8000/api/physical-light/set-brightness', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ brightness: value })
-      }).catch(e => console.warn('[PhysicalLightBarPanel] Failed to set brightness:', e));
+      fetch("http://localhost:8000/api/physical-light/set-brightness", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ brightness: value }),
+      }).catch((e) =>
+        console.warn("[PhysicalLightBarPanel] Failed to set brightness:", e),
+      );
     }
   }, [value, visible]);
 
   if (!visible) return null;
   return (
-    <div className="bg-gray-900 text-white p-4 rounded-lg shadow-lg mb-2 flex flex-col items-center" style={{ minWidth: 260 }}>
+    <div
+      className="bg-gray-900 text-white p-4 rounded-lg shadow-lg mb-2 flex flex-col items-center"
+      style={{ minWidth: 260 }}
+    >
       <div className="flex w-full items-center mb-2">
         <span className="mr-2">亮度</span>
         <input
@@ -105,12 +120,17 @@ function PhysicalLightBarPanel({ visible, onClose }: { visible: boolean, onClose
           min={0}
           max={65535}
           value={value}
-          onChange={e => setValue(Number(e.target.value))}
+          onChange={(e) => setValue(Number(e.target.value))}
           className="flex-1 mx-2"
         />
         <span className="ml-2 text-xs">{value}</span>
       </div>
-      <button onClick={onClose} className="mt-2 px-3 py-1 bg-gray-700 rounded hover:bg-gray-600 text-xs">關閉</button>
+      <button
+        onClick={onClose}
+        className="mt-2 px-3 py-1 bg-gray-700 rounded hover:bg-gray-600 text-xs"
+      >
+        關閉
+      </button>
     </div>
   );
 }
@@ -134,6 +154,8 @@ const AppUI: React.FC<AppUIProps> = ({
   toggleEnvironmentControlPanel,
   // 排程控制面板控制
   toggleRealtimeSchedulePanel,
+  // 文字顯示面板控制
+  toggleTextPanel,
   toggleRealtime,
   realtimeStreaming,
   realtimeError,
@@ -171,120 +193,142 @@ const AppUI: React.FC<AppUIProps> = ({
 
       {/* Keep Debug Buttons and Trigger Buttons */}
       {isSideButtonsVisible && (
-        <div 
+        <div
           // Container for bottom-right buttons (Use Tailwind)
           className="fixed bottom-5 right-5 z-[1000] flex flex-col items-end space-y-2"
         >
-        {/* Trigger Floating Chat Window Button */}
-        <button
-          onClick={toggleChatWindow}
-          // Apply Tailwind classes
-          className="w-12 h-12 rounded-full bg-green-500 hover:bg-green-600 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
-          title="開啟/關閉聊天視窗"
-          aria-label="開啟/關閉聊天視窗"
-        >
-          💬
-        </button>
-
-        {/* Real-time Voice Button */}
-        <div className="flex flex-col items-end">
+          {/* Trigger Floating Chat Window Button */}
           <button
-            onClick={toggleRealtime}
-            className={`
+            onClick={toggleChatWindow}
+            // Apply Tailwind classes
+            className="w-12 h-12 rounded-full bg-green-500 hover:bg-green-600 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
+            title="開啟/關閉聊天視窗"
+            aria-label="開啟/關閉聊天視窗"
+          >
+            💬
+          </button>
+
+          {/* Real-time Voice Button */}
+          <div className="flex flex-col items-end">
+            <button
+              onClick={toggleRealtime}
+              className={`
               relative w-12 h-12 rounded-full shadow-md flex items-center justify-center cursor-pointer transition-all duration-200
-              ${realtimeStreaming
-                ? 'bg-red-600 hover:bg-red-700 animate-pulse ring-2 ring-red-300'
-                : realtimeError
-                  ? 'bg-red-400 hover:bg-red-500'
-                  : 'bg-red-500 hover:bg-red-600'
+              ${
+                realtimeStreaming
+                  ? "bg-red-600 hover:bg-red-700 animate-pulse ring-2 ring-red-300"
+                  : realtimeError
+                    ? "bg-red-400 hover:bg-red-500"
+                    : "bg-red-500 hover:bg-red-600"
               }
               text-white text-2xl
             `}
-            title={realtimeStreaming ? '停止實時語音通話 (空白鍵)' : '啟動實時語音通話 (空白鍵)'}
-            aria-label={realtimeStreaming ? '停止實時語音通話 (空白鍵)' : '啟動實時語音通話 (空白鍵)'}
-          >
-            {realtimeStreaming ? '🔴' : '🎤'}
-            {realtimeStreaming && (
-              <div className="absolute -top-1 -right-1 w-3 h-3 bg-green-400 rounded-full animate-ping"></div>
+              title={
+                realtimeStreaming
+                  ? "停止實時語音通話 (空白鍵)"
+                  : "啟動實時語音通話 (空白鍵)"
+              }
+              aria-label={
+                realtimeStreaming
+                  ? "停止實時語音通話 (空白鍵)"
+                  : "啟動實時語音通話 (空白鍵)"
+              }
+            >
+              {realtimeStreaming ? "🔴" : "🎤"}
+              {realtimeStreaming && (
+                <div className="absolute -top-1 -right-1 w-3 h-3 bg-green-400 rounded-full animate-ping"></div>
+              )}
+            </button>
+
+            {/* 錯誤提示 */}
+            {realtimeError && (
+              <div className="mt-1 bg-red-100 border border-red-400 text-red-700 px-2 py-1 rounded text-xs max-w-48">
+                {realtimeError}
+              </div>
             )}
+          </div>
+
+          {/* Trigger Settings Panel Button */}
+          <button
+            onClick={toggleSettingsPanel}
+            // Apply Tailwind classes
+            className="w-12 h-12 rounded-full bg-gray-600 hover:bg-gray-700 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
+            title="開啟/關閉設定面板"
+            aria-label="開啟/關閉設定面板"
+          >
+            ⚙️
           </button>
-          
-          {/* 錯誤提示 */}
-          {realtimeError && (
-            <div className="mt-1 bg-red-100 border border-red-400 text-red-700 px-2 py-1 rounded text-xs max-w-48">
-              {realtimeError}
-            </div>
-          )}
-        </div>
 
-        {/* Trigger Settings Panel Button */}
-        <button
-          onClick={toggleSettingsPanel}
-          // Apply Tailwind classes
-          className="w-12 h-12 rounded-full bg-gray-600 hover:bg-gray-700 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
-          title="開啟/關閉設定面板"
-          aria-label="開啟/關閉設定面板"
-        >
-          ⚙️
-        </button>
+          {/* Trigger Room Control Panel Button */}
+          <button
+            onClick={toggleRoomControlPanel}
+            // Apply Tailwind classes
+            className="w-12 h-12 rounded-full bg-purple-600 hover:bg-purple-700 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
+            title="開啟/關閉房間場景控制"
+            aria-label="開啟/關閉房間場景控制"
+          >
+            🏠
+          </button>
 
-        {/* Trigger Room Control Panel Button */}
-        <button
-          onClick={toggleRoomControlPanel}
-          // Apply Tailwind classes
-          className="w-12 h-12 rounded-full bg-purple-600 hover:bg-purple-700 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
-          title="開啟/關閉房間場景控制"
-          aria-label="開啟/關閉房間場景控制"
-        >
-          🏠
-        </button>
+          {/* Trigger Character Control Panel Button */}
+          <button
+            onClick={toggleCharacterControlPanel}
+            // Apply Tailwind classes
+            className="w-12 h-12 rounded-full bg-orange-600 hover:bg-orange-700 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
+            title="開啟/關閉角色控制面板"
+            aria-label="開啟/關閉角色控制面板"
+          >
+            🚶
+          </button>
 
-        {/* Trigger Character Control Panel Button */}
-        <button
-          onClick={toggleCharacterControlPanel}
-          // Apply Tailwind classes
-          className="w-12 h-12 rounded-full bg-orange-600 hover:bg-orange-700 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
-          title="開啟/關閉角色控制面板"
-          aria-label="開啟/關閉角色控制面板"
-        >
-          🚶
-        </button>
+          {/* Trigger Environment Control Panel Button */}
+          <button
+            onClick={toggleEnvironmentControlPanel}
+            // Apply Tailwind classes
+            className="w-12 h-12 rounded-full bg-yellow-600 hover:bg-yellow-700 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
+            title="開啟/關閉環境光照控制"
+            aria-label="開啟/關閉環境光照控制"
+          >
+            ✨
+          </button>
 
-        {/* Trigger Environment Control Panel Button */}
-        <button
-          onClick={toggleEnvironmentControlPanel}
-          // Apply Tailwind classes
-          className="w-12 h-12 rounded-full bg-yellow-600 hover:bg-yellow-700 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
-          title="開啟/關閉環境光照控制"
-          aria-label="開啟/關閉環境光照控制"
-        >
-          ✨
-        </button>
+          {/* Trigger Realtime Schedule Panel Button */}
+          <button
+            onClick={toggleRealtimeSchedulePanel}
+            className="w-12 h-12 rounded-full bg-purple-600 hover:bg-purple-700 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
+            title="開啟/關閉即時對話排程控制"
+            aria-label="開啟/關閉即時對話排程控制"
+          >
+            ⏰
+          </button>
 
-        {/* Trigger Realtime Schedule Panel Button */}
-        <button
-          onClick={toggleRealtimeSchedulePanel}
-          className="w-12 h-12 rounded-full bg-purple-600 hover:bg-purple-700 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
-          title="開啟/關閉即時對話排程控制"
-          aria-label="開啟/關閉即時對話排程控制"
-        >
-          ⏰
-        </button>
-        {/* === 新增：物理燈條控制 toggle 按鈕 === */}
-        <button
-          onClick={() => setShowLightBar((v) => !v)}
-          className="w-12 h-12 rounded-full bg-blue-600 hover:bg-blue-700 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
-          title="開啟/關閉物理燈條控制"
-          aria-label="開啟/關閉物理燈條控制"
-        >
-          💡
-        </button>
-        <PhysicalLightBarPanel visible={showLightBar} onClose={() => setShowLightBar(false)} />
-        {/* === 新增結束 === */}
+          {/* Trigger Text Display Panel Button */}
+          <button
+            onClick={toggleTextPanel}
+            className="w-12 h-12 rounded-full bg-teal-600 hover:bg-teal-700 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
+            title="開啟/關閉文字顯示面板"
+            aria-label="開啟/關閉文字顯示面板"
+          >
+            📝
+          </button>
+          {/* === 新增：物理燈條控制 toggle 按鈕 === */}
+          <button
+            onClick={() => setShowLightBar((v) => !v)}
+            className="w-12 h-12 rounded-full bg-blue-600 hover:bg-blue-700 text-white text-2xl shadow-md flex items-center justify-center cursor-pointer transition-colors duration-200"
+            title="開啟/關閉物理燈條控制"
+            aria-label="開啟/關閉物理燈條控制"
+          >
+            💡
+          </button>
+          <PhysicalLightBarPanel
+            visible={showLightBar}
+            onClose={() => setShowLightBar(false)}
+          />
+          {/* === 新增結束 === */}
         </div>
       )}
     </>
   );
 };
 
-export default AppUI; 
+export default AppUI;

--- a/prototype/frontend/src/services/api.ts
+++ b/prototype/frontend/src/services/api.ts
@@ -4,9 +4,10 @@
  */
 
 // API基礎URL - 移除production模式中的'/api'前綴，因為後端路由已包含'/api'前綴
-const API_BASE_URL = import.meta.env.MODE === 'production'
-  ? window.location.origin
-  : `http://${window.location.hostname}:8000`;
+const API_BASE_URL =
+  import.meta.env.MODE === "production"
+    ? window.location.origin
+    : `http://${window.location.hostname}:8000`;
 
 // 可能的API錯誤類型
 export class ApiError extends Error {
@@ -15,7 +16,7 @@ export class ApiError extends Error {
 
   constructor(message: string, status: number, data: any = null) {
     super(message);
-    this.name = 'ApiError';
+    this.name = "ApiError";
     this.status = status;
     this.data = data;
   }
@@ -36,15 +37,17 @@ type ApiResponse<T> = {
  * @returns 響應數據
  */
 async function fetchApi<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const fullUrl = url.startsWith('http') ? url : `${API_BASE_URL}${url.startsWith('/') ? url : `/${url}`}`;
-  
+  const fullUrl = url.startsWith("http")
+    ? url
+    : `${API_BASE_URL}${url.startsWith("/") ? url : `/${url}`}`;
+
   // 默認請求設置
   const defaultOptions: RequestInit = {
     headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json',
+      "Content-Type": "application/json",
+      Accept: "application/json",
     },
-    credentials: 'omit', // 不包含cookies
+    credentials: "omit", // 不包含cookies
   };
 
   // 合併選項
@@ -59,12 +62,12 @@ async function fetchApi<T>(url: string, options: RequestInit = {}): Promise<T> {
 
   try {
     const response = await fetch(fullUrl, fetchOptions);
-    
+
     // 檢查是否為JSON響應
-    const contentType = response.headers.get('content-type');
+    const contentType = response.headers.get("content-type");
     let data: any;
-    
-    if (contentType && contentType.includes('application/json')) {
+
+    if (contentType && contentType.includes("application/json")) {
       data = await response.json();
     } else {
       data = await response.text();
@@ -72,7 +75,12 @@ async function fetchApi<T>(url: string, options: RequestInit = {}): Promise<T> {
 
     // 處理非200響應
     if (!response.ok) {
-      let errorMessage = typeof data === 'string' ? data : (data.error || data.message || `請求失敗，狀態碼: ${response.status}`);
+      let errorMessage =
+        typeof data === "string"
+          ? data
+          : data.error ||
+            data.message ||
+            `請求失敗，狀態碼: ${response.status}`;
       throw new ApiError(errorMessage, response.status, data);
     }
 
@@ -82,13 +90,13 @@ async function fetchApi<T>(url: string, options: RequestInit = {}): Promise<T> {
     if (error instanceof ApiError) {
       throw error;
     }
-    
+
     // 網絡錯誤或其他異常
-    console.error('API請求錯誤:', error);
+    console.error("API請求錯誤:", error);
     throw new ApiError(
-      error instanceof Error ? error.message : '網絡請求失敗',
+      error instanceof Error ? error.message : "網絡請求失敗",
       0,
-      { originalError: error }
+      { originalError: error },
     );
   }
 }
@@ -98,13 +106,13 @@ async function fetchApi<T>(url: string, options: RequestInit = {}): Promise<T> {
  * @param text 要分析的文本
  * @returns 分析結果
  */
-export async function analyzeText(text: string): Promise<{ 
-  response: string; 
+export async function analyzeText(text: string): Promise<{
+  response: string;
   emotion?: string;
   confidence?: number;
 }> {
-  return fetchApi('/api/analyze_text', {
-    method: 'POST',
+  return fetchApi("/api/analyze_text", {
+    method: "POST",
     body: JSON.stringify({ text }),
   });
 }
@@ -114,12 +122,12 @@ export async function analyzeText(text: string): Promise<{
  * @param text 要轉換為語音的文本
  * @returns 音頻URL
  */
-export async function generateSpeech(text: string): Promise<{ 
+export async function generateSpeech(text: string): Promise<{
   audio_url: string;
-  duration?: number; 
+  duration?: number;
 }> {
-  return fetchApi('/api/text_to_speech', {
-    method: 'POST',
+  return fetchApi("/api/text_to_speech", {
+    method: "POST",
     body: JSON.stringify({ text }),
   });
 }
@@ -129,14 +137,14 @@ export async function generateSpeech(text: string): Promise<{
  * @param audioBlob 音頻Blob數據
  * @returns 轉換結果
  */
-export async function speechToText(audioBlob: Blob): Promise<{ 
+export async function speechToText(audioBlob: Blob): Promise<{
   text: string;
   confidence?: number;
 }> {
-  return fetchApi('/api/speech-to-text', {
-    method: 'POST',
+  return fetchApi("/api/speech-to-text", {
+    method: "POST",
     headers: {
-      'Content-Type': 'audio/webm; codecs=opus',
+      "Content-Type": "audio/webm; codecs=opus",
     },
     body: audioBlob,
   });
@@ -148,20 +156,20 @@ export async function speechToText(audioBlob: Blob): Promise<{
  * @returns 包含識別文本、AI回應、音頻Base64等的對象
  */
 export async function processSpeechAudio(audioBlob: Blob): Promise<{
-  text: string;          // 語音識別出的文字
-  response: string;      // AI生成的回應文字
-  audio?: string;         // TTS生成的音頻 Base64 字串
-  confidence?: number;    // STT 置信度 (可能為 null)
-  success: boolean;        // 操作是否成功
-  error?: string;         // 錯誤訊息
+  text: string; // 語音識別出的文字
+  response: string; // AI生成的回應文字
+  audio?: string; // TTS生成的音頻 Base64 字串
+  confidence?: number; // STT 置信度 (可能為 null)
+  success: boolean; // 操作是否成功
+  error?: string; // 錯誤訊息
 }> {
   // 注意：端點名稱與 speechToText 相同，但期望的回應不同
-  return fetchApi('/api/speech-to-text', {
-    method: 'POST',
+  return fetchApi("/api/speech-to-text", {
+    method: "POST",
     headers: {
       // 確保 Content-Type 正確
-      'Content-Type': audioBlob.type || 'audio/webm; codecs=opus',
-      'Accept': 'application/json', // 確保接受 JSON
+      "Content-Type": audioBlob.type || "audio/webm; codecs=opus",
+      Accept: "application/json", // 確保接受 JSON
     },
     body: audioBlob,
   });
@@ -171,24 +179,26 @@ export async function processSpeechAudio(audioBlob: Blob): Promise<{
  * 健康檢查API
  * @returns 服務狀態
  */
-export async function checkHealth(): Promise<{ 
+export async function checkHealth(): Promise<{
   status: string;
   version?: string;
 }> {
-  return fetchApi('/api/health');
+  return fetchApi("/api/health");
 }
 
 /**
  * 獲取可用語音配置
  * @returns 語音配置列表
  */
-export async function getVoiceConfigs(): Promise<{
-  id: string;
-  name: string;
-  language_code: string;
-  gender: string;
-}[]> {
-  return fetchApi('/api/voices');
+export async function getVoiceConfigs(): Promise<
+  {
+    id: string;
+    name: string;
+    language_code: string;
+    gender: string;
+  }[]
+> {
+  return fetchApi("/api/voices");
 }
 
 /**
@@ -196,9 +206,11 @@ export async function getVoiceConfigs(): Promise<{
  * @param voiceId 語音配置ID
  * @returns 操作結果
  */
-export async function setVoiceConfig(voiceId: string): Promise<{ success: boolean }> {
-  return fetchApi('/api/set_voice', {
-    method: 'POST',
+export async function setVoiceConfig(
+  voiceId: string,
+): Promise<{ success: boolean }> {
+  return fetchApi("/api/set_voice", {
+    method: "POST",
     body: JSON.stringify({ voice_id: voiceId }),
   });
 }
@@ -208,12 +220,14 @@ export async function setVoiceConfig(voiceId: string): Promise<{ success: boolea
  * @param limit 最大日誌條目數
  * @returns 日誌條目列表
  */
-export async function getLogs(limit: number = 100): Promise<{
-  level: string;
-  timestamp: string;
-  message: string;
-  context?: Record<string, any>;
-}[]> {
+export async function getLogs(limit: number = 100): Promise<
+  {
+    level: string;
+    timestamp: string;
+    message: string;
+    context?: Record<string, any>;
+  }[]
+> {
   return fetchApi(`/api/logs?limit=${limit}`);
 }
 
@@ -224,7 +238,7 @@ export async function getLogs(limit: number = 100): Promise<{
 export async function getPresetsList(): Promise<{
   presets: string[];
 }> {
-  return fetchApi('/api/presets');
+  return fetchApi("/api/presets");
 }
 
 /**
@@ -232,8 +246,29 @@ export async function getPresetsList(): Promise<{
  * @param expression 表情類型
  * @returns 表情變形目標
  */
-export async function getPresetExpression(expression: string): Promise<Record<string, number>> {
+export async function getPresetExpression(
+  expression: string,
+): Promise<Record<string, number>> {
   return fetchApi(`/api/preset-expressions/${expression}`);
+}
+
+/**
+ * 取得要顯示的文字
+ */
+export async function getDisplayText(): Promise<{ text: string }> {
+  return fetchApi("/api/display_text");
+}
+
+/**
+ * 設定要顯示的文字
+ */
+export async function setDisplayText(
+  text: string,
+): Promise<{ success: boolean }> {
+  return fetchApi("/api/display_text", {
+    method: "POST",
+    body: JSON.stringify({ text }),
+  });
 }
 
 // 導出API服務
@@ -248,6 +283,8 @@ const apiService = {
   getLogs,
   getPresetsList,
   getPresetExpression,
+  getDisplayText,
+  setDisplayText,
 };
 
-export default apiService; 
+export default apiService;

--- a/prototype/frontend/src/store/slices/appSlice.ts
+++ b/prototype/frontend/src/store/slices/appSlice.ts
@@ -1,10 +1,10 @@
-import { StateCreator } from 'zustand';
+import { StateCreator } from "zustand";
 
 // Toast類型定義
 export interface Toast {
   id: string;
   message: string;
-  type: 'error' | 'success' | 'info';
+  type: "error" | "success" | "info";
   duration?: number;
 }
 
@@ -19,35 +19,37 @@ export interface AppSlice {
   isCharacterControlPanelVisible: boolean;
   isEnvironmentControlPanelVisible: boolean;
   isRealtimeSchedulePanelVisible: boolean;
+  isTextPanelVisible: boolean;
   isSideButtonsVisible: boolean; // 控制右側按鈕的顯示/隱藏
   isLoading: boolean;
   errorMessage: string | null;
   currentAction: string | null;
   userInteracted: boolean;
-  micPermission: 'prompt' | 'granted' | 'denied';
+  micPermission: "prompt" | "granted" | "denied";
   audioDuration: number | null;
   // 背景圖片相關狀態
   currentBackgroundPicture: string | null;
   availableBackgroundPictures: string[];
   backgroundPictureEnabled: boolean;
-  
+
   // 操作
   setActiveTab: (tab: string) => void;
   toggleDebugMode: () => void;
   setCameraDistance: (isFar: boolean) => void;
-  addToast: (toast: Omit<Toast, 'id'>) => void;
+  addToast: (toast: Omit<Toast, "id">) => void;
   removeToast: (id: string) => void;
   clearToasts: () => void;
   toggleSettingsPanel: () => void;
   toggleCharacterControlPanel: () => void;
   toggleEnvironmentControlPanel: () => void;
   toggleRealtimeSchedulePanel: () => void;
+  toggleTextPanel: () => void;
   toggleSideButtons: () => void; // 切換右側按鈕顯示狀態
   setLoading: (loading: boolean) => void;
   setError: (message: string | null) => void;
   setCurrentAction: (action: string | null) => void;
   setUserInteracted: () => void;
-  setMicPermission: (permission: 'prompt' | 'granted' | 'denied') => void;
+  setMicPermission: (permission: "prompt" | "granted" | "denied") => void;
   setAudioDuration: (duration: number | null) => void;
   // 背景圖片相關操作
   setCurrentBackgroundPicture: (picture: string | null) => void;
@@ -59,7 +61,7 @@ export interface AppSlice {
 // 創建 App Slice
 export const createAppSlice: StateCreator<AppSlice> = (set) => ({
   // 初始狀態
-  activeTab: 'control', // 'control' | 'chat'
+  activeTab: "control", // 'control' | 'chat'
   isDebugMode: false,
   isCameraFar: true,
   toasts: [],
@@ -67,67 +69,99 @@ export const createAppSlice: StateCreator<AppSlice> = (set) => ({
   isCharacterControlPanelVisible: false,
   isEnvironmentControlPanelVisible: false,
   isRealtimeSchedulePanelVisible: false,
+  isTextPanelVisible: false,
   isSideButtonsVisible: true, // 預設顯示右側按鈕
   isLoading: false,
   errorMessage: null,
   currentAction: null,
   userInteracted: false,
-  micPermission: 'prompt',
+  micPermission: "prompt",
   audioDuration: null,
   // 背景圖片初始狀態
   currentBackgroundPicture: null,
-  availableBackgroundPictures: ['outerspace1.png', 'outerspace2.png', 'outerspace3.png'],
+  availableBackgroundPictures: [
+    "outerspace1.png",
+    "outerspace2.png",
+    "outerspace3.png",
+  ],
   backgroundPictureEnabled: false,
-  
+
   // 操作實現
   setActiveTab: (tab) => set({ activeTab: tab }),
-  
-  toggleDebugMode: () => set((state) => ({ 
-    isDebugMode: !state.isDebugMode 
-  })),
-  
+
+  toggleDebugMode: () =>
+    set((state) => ({
+      isDebugMode: !state.isDebugMode,
+    })),
+
   setCameraDistance: (isFar) => set({ isCameraFar: isFar }),
-  
-  addToast: (toast) => set((state) => ({
-    toasts: [...state.toasts, { ...toast, id: `toast-${Date.now()}-${Math.random().toString(36).substr(2, 9)}` }]
-  })),
-  
-  removeToast: (id) => set((state) => ({
-    toasts: state.toasts.filter(toast => toast.id !== id)
-  })),
-  
+
+  addToast: (toast) =>
+    set((state) => ({
+      toasts: [
+        ...state.toasts,
+        {
+          ...toast,
+          id: `toast-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+        },
+      ],
+    })),
+
+  removeToast: (id) =>
+    set((state) => ({
+      toasts: state.toasts.filter((toast) => toast.id !== id),
+    })),
+
   clearToasts: () => set({ toasts: [] }),
-  
-  toggleSettingsPanel: () => set((state) => ({ isSettingsPanelVisible: !state.isSettingsPanelVisible })),
-  
-  toggleCharacterControlPanel: () => set((state) => ({ isCharacterControlPanelVisible: !state.isCharacterControlPanelVisible })),
-  
-  toggleEnvironmentControlPanel: () => set((state) => ({ isEnvironmentControlPanelVisible: !state.isEnvironmentControlPanelVisible })),
-  
-  toggleRealtimeSchedulePanel: () => set((state) => ({ isRealtimeSchedulePanelVisible: !state.isRealtimeSchedulePanelVisible })),
-  
-  toggleSideButtons: () => set((state) => ({ isSideButtonsVisible: !state.isSideButtonsVisible })),
-  
+
+  toggleSettingsPanel: () =>
+    set((state) => ({ isSettingsPanelVisible: !state.isSettingsPanelVisible })),
+
+  toggleCharacterControlPanel: () =>
+    set((state) => ({
+      isCharacterControlPanelVisible: !state.isCharacterControlPanelVisible,
+    })),
+
+  toggleEnvironmentControlPanel: () =>
+    set((state) => ({
+      isEnvironmentControlPanelVisible: !state.isEnvironmentControlPanelVisible,
+    })),
+
+  toggleRealtimeSchedulePanel: () =>
+    set((state) => ({
+      isRealtimeSchedulePanelVisible: !state.isRealtimeSchedulePanelVisible,
+    })),
+
+  toggleTextPanel: () =>
+    set((state) => ({ isTextPanelVisible: !state.isTextPanelVisible })),
+
+  toggleSideButtons: () =>
+    set((state) => ({ isSideButtonsVisible: !state.isSideButtonsVisible })),
+
   setLoading: (loading) => set({ isLoading: loading }),
-  
+
   setError: (message) => set({ errorMessage: message }),
-  
+
   setCurrentAction: (action) => set({ currentAction: action }),
-  
+
   setUserInteracted: () => set({ userInteracted: true }),
-  
+
   setMicPermission: (permission) => set({ micPermission: permission }),
-  
+
   setAudioDuration: (duration) => set({ audioDuration: duration }),
-  
+
   // 背景圖片操作實現
-  setCurrentBackgroundPicture: (picture) => set({ currentBackgroundPicture: picture }),
-  
-  setAvailableBackgroundPictures: (pictures) => set({ availableBackgroundPictures: pictures }),
-  
-  toggleBackgroundPicture: () => set((state) => ({ 
-    backgroundPictureEnabled: !state.backgroundPictureEnabled 
-  })),
-  
-  setBackgroundPictureEnabled: (enabled) => set({ backgroundPictureEnabled: enabled }),
-}); 
+  setCurrentBackgroundPicture: (picture) =>
+    set({ currentBackgroundPicture: picture }),
+
+  setAvailableBackgroundPictures: (pictures) =>
+    set({ availableBackgroundPictures: pictures }),
+
+  toggleBackgroundPicture: () =>
+    set((state) => ({
+      backgroundPictureEnabled: !state.backgroundPictureEnabled,
+    })),
+
+  setBackgroundPictureEnabled: (enabled) =>
+    set({ backgroundPictureEnabled: enabled }),
+});


### PR DESCRIPTION
## Summary
- add FastAPI `display_text` endpoint to store and retrieve text
- add front-end TextDisplayPanel and API helpers with toggle in UI
- document new text panel feature

## Testing
- `isort api/endpoints/display_text.py tests/test_display_text.py api/__init__.py`
- `black api/endpoints/display_text.py tests/test_display_text.py api/__init__.py`
- `mypy api/endpoints/display_text.py tests/test_display_text.py api/__init__.py` *(fails: Library stubs not installed, cannot find fastapi, websockets, etc.)*
- `pytest` *(fails: ModuleNotFoundError: fastapi, websockets)*
- `npm run lint` *(fails: 213 problems with eslint configuration)*
- `npm test` *(fails: react-scripts not found)*
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ac918971948321ae95691461b31bd3