### PR TITLE
feat: add autoplay scheduler with random yoga support

### DIFF
--- a/docs/backend/script_execution_api.md
+++ b/docs/backend/script_execution_api.md
@@ -21,6 +21,7 @@
 | `/api/scripts/execute` | POST | 執行指定腳本 |
 | `/api/scripts/status` | GET | 查看執行狀態 |
 | `/api/scripts/stop/{script_name}` | POST | 停止執行中的腳本 |
+| `/api/scripts/execute/random-yoga` | POST | 隨機執行瑜伽腳本，支援 `count` 參數 |
 
 ## 🎭 可用腳本
 
@@ -85,9 +86,12 @@ curl -X POST "http://localhost:8000/api/scripts/execute" \
   -H "Content-Type: application/json" \
   -d '{
     "script_name": "meta_self.sh",
-    "background": true
+    "background": true,
+    "args": ["--foo", "bar"]
   }'
 ```
+
+其中 `args` 陣列為可選，用於向腳本傳遞參數。
 
 **回應範例:**
 ```json
@@ -116,6 +120,17 @@ curl -X GET "http://localhost:8000/api/scripts/status"
 ```bash
 curl -X POST "http://localhost:8000/api/scripts/stop/meta_self.sh"
 ```
+
+### 5. 隨機播放瑜伽腳本
+```bash
+curl -X POST "http://localhost:8000/api/scripts/execute/random-yoga" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "count": 3
+  }'
+```
+
+上述範例將呼叫 `run_yoga_random_playlist.sh` 並播放 3 個隨機瑜伽腳本。
 
 **回應範例:**
 ```json

--- a/prototype/backend/api/endpoints/scripts.py
+++ b/prototype/backend/api/endpoints/scripts.py
@@ -1,10 +1,12 @@
-from fastapi import APIRouter, HTTPException, BackgroundTasks
-from pydantic import BaseModel
-from typing import Dict, Optional, List
+import asyncio
 import os
 import subprocess
-import asyncio
 from pathlib import Path
+from typing import Dict, List, Optional
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException
+from pydantic import BaseModel
+
 from utils.logger import logger
 
 router = APIRouter()
@@ -17,6 +19,7 @@ router = APIRouter()
 # 腳本基礎路徑
 SCRIPTS_DIR = Path(__file__).parent.parent.parent / "experiment_scripts"
 YOGA_DIR = SCRIPTS_DIR / "yoga_sessions"
+
 
 def _scan_yoga_scripts() -> list[str]:
     try:
@@ -31,12 +34,16 @@ def _scan_yoga_scripts() -> list[str]:
     except Exception:
         return []
 
+
 # 已註冊的腳本列表（僅 yoga_sessions 內檔案）
 REGISTERED_SCRIPTS = _scan_yoga_scripts()
+
 
 class ScriptExecutionRequest(BaseModel):
     script_name: str
     background: bool = True  # 預設在背景執行
+    args: Optional[List[str]] = None  # 允許附加參數
+
 
 class ScriptExecutionResponse(BaseModel):
     success: bool
@@ -44,8 +51,10 @@ class ScriptExecutionResponse(BaseModel):
     script_name: str
     execution_mode: str
 
+
 # 儲存正在執行的腳本狀態
 running_scripts: Dict[str, subprocess.Popen] = {}
+
 
 @router.get("/scripts/list")
 async def list_registered_scripts():
@@ -53,7 +62,7 @@ async def list_registered_scripts():
     列出所有已註冊可執行的腳本
     """
     scripts_info = []
-    
+
     # 重新掃描以確保清單最新（避免重啟前後清單不同步）
     global REGISTERED_SCRIPTS
     REGISTERED_SCRIPTS = _scan_yoga_scripts()
@@ -63,132 +72,166 @@ async def list_registered_scripts():
         if script_path.exists():
             # 讀取腳本前幾行來獲取描述
             try:
-                with open(script_path, 'r', encoding='utf-8') as f:
+                with open(script_path, "r", encoding="utf-8") as f:
                     lines = f.readlines()[:10]  # 讀取前10行
                     description = ""
                     for line in lines:
-                        if line.strip().startswith('#') and '---' in line:
-                            description = line.strip().replace('#', '').replace('-', '').strip()
+                        if line.strip().startswith("#") and "---" in line:
+                            description = (
+                                line.strip().replace("#", "").replace("-", "").strip()
+                            )
                             break
-                
-                scripts_info.append({
-                    "name": script_name,
-                    "description": description or "無描述",
-                    "exists": True,
-                    "is_running": script_name in running_scripts
-                })
+
+                scripts_info.append(
+                    {
+                        "name": script_name,
+                        "description": description or "無描述",
+                        "exists": True,
+                        "is_running": script_name in running_scripts,
+                    }
+                )
             except Exception as e:
-                scripts_info.append({
-                    "name": script_name,
-                    "description": f"讀取錯誤: {str(e)}",
-                    "exists": True,
-                    "is_running": script_name in running_scripts
-                })
+                scripts_info.append(
+                    {
+                        "name": script_name,
+                        "description": f"讀取錯誤: {str(e)}",
+                        "exists": True,
+                        "is_running": script_name in running_scripts,
+                    }
+                )
         else:
-            scripts_info.append({
-                "name": script_name,
-                "description": "腳本檔案不存在",
-                "exists": False,
-                "is_running": False
-            })
-    
+            scripts_info.append(
+                {
+                    "name": script_name,
+                    "description": "腳本檔案不存在",
+                    "exists": False,
+                    "is_running": False,
+                }
+            )
+
     return {
         "registered_scripts": scripts_info,
         "total_count": len(REGISTERED_SCRIPTS),
-        "running_count": len(running_scripts)
+        "running_count": len(running_scripts),
     }
 
+
 @router.post("/scripts/execute", response_model=ScriptExecutionResponse)
-async def execute_script(request: ScriptExecutionRequest, background_tasks: BackgroundTasks):
+async def execute_script(
+    request: ScriptExecutionRequest, background_tasks: BackgroundTasks
+):
     """
     執行指定的腳本
     """
     script_name = request.script_name
-    
+
     # 安全性檢查：只允許執行已註冊的腳本
     if script_name not in REGISTERED_SCRIPTS:
         raise HTTPException(
             status_code=400,
-            detail=f"腳本 '{script_name}' 未註冊。請使用 /scripts/list 查看可用腳本。"
+            detail=f"腳本 '{script_name}' 未註冊。請使用 /scripts/list 查看可用腳本。",
         )
-    
+
     script_path = SCRIPTS_DIR / script_name
-    
+
     # 檢查腳本是否存在
     if not script_path.exists():
         raise HTTPException(
-            status_code=404,
-            detail=f"腳本檔案 '{script_name}' 不存在於 {SCRIPTS_DIR}"
+            status_code=404, detail=f"腳本檔案 '{script_name}' 不存在於 {SCRIPTS_DIR}"
         )
-    
+
     # 檢查腳本是否已在執行
     if script_name in running_scripts:
         raise HTTPException(
-            status_code=409,
-            detail=f"腳本 '{script_name}' 目前正在執行中"
+            status_code=409, detail=f"腳本 '{script_name}' 目前正在執行中"
         )
-    
+
     logger.info(f"準備執行腳本: {script_name}")
-    
+
     try:
         if request.background:
             # 背景執行
-            background_tasks.add_task(run_script_background, script_path, script_name)
+            background_tasks.add_task(
+                run_script_background, script_path, script_name, request.args
+            )
             return ScriptExecutionResponse(
                 success=True,
                 message=f"腳本 '{script_name}' 已開始在背景執行",
                 script_name=script_name,
-                execution_mode="background"
+                execution_mode="background",
             )
         else:
             # 同步執行（等待完成）
-            result = await run_script_sync(script_path, script_name)
+            result = await run_script_sync(script_path, script_name, request.args)
             return ScriptExecutionResponse(
                 success=result["success"],
                 message=result["message"],
                 script_name=script_name,
-                execution_mode="synchronous"
+                execution_mode="synchronous",
             )
-            
+
     except Exception as e:
         logger.error(f"執行腳本時發生錯誤: {str(e)}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"執行腳本時發生錯誤: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"執行腳本時發生錯誤: {str(e)}")
+
+
+class RandomYogaRequest(BaseModel):
+    count: Optional[int] = None
+
 
 @router.post("/scripts/execute/random-yoga", response_model=ScriptExecutionResponse)
-async def execute_random_yoga_script(background_tasks: BackgroundTasks):
+async def execute_random_yoga_script(
+    request: RandomYogaRequest, background_tasks: BackgroundTasks
+):
     """
     隨機執行 yoga_sessions 目錄中的任一已註冊腳本（背景執行）。
     若所有腳本都在執行中，將返回 409。
+    若提供 count 參數，則執行 run_yoga_random_playlist.sh 並附帶 --count。
     """
+    if request.count is not None:
+        if request.count <= 0:
+            raise HTTPException(status_code=400, detail="count 必須為正整數")
+        script_name = "yoga_sessions/run_yoga_random_playlist.sh"
+        script_path = SCRIPTS_DIR / script_name
+        if not script_path.exists():
+            raise HTTPException(
+                status_code=404, detail="找不到 run_yoga_random_playlist.sh"
+            )
+        args = ["--count", str(request.count)]
+        background_tasks.add_task(run_script_background, script_path, script_name, args)
+        return ScriptExecutionResponse(
+            success=True,
+            message=f"腳本 '{script_name}' 已開始在背景執行",
+            script_name=script_name,
+            execution_mode="background",
+        )
+
     global REGISTERED_SCRIPTS
     if not REGISTERED_SCRIPTS:
         REGISTERED_SCRIPTS = _scan_yoga_scripts()
     if not REGISTERED_SCRIPTS:
         raise HTTPException(status_code=404, detail="找不到可用的瑜伽腳本")
 
-    # 過濾尚未在執行的腳本
     available = [s for s in REGISTERED_SCRIPTS if s not in running_scripts]
     if not available:
         raise HTTPException(status_code=409, detail="所有瑜伽腳本目前都在執行中")
 
     import random
+
     script_name = random.choice(available)
     script_path = SCRIPTS_DIR / script_name
 
     if not script_path.exists():
         raise HTTPException(status_code=404, detail=f"腳本檔案不存在: {script_name}")
 
-    # 背景執行
     background_tasks.add_task(run_script_background, script_path, script_name)
     return ScriptExecutionResponse(
         success=True,
         message=f"腳本 '{script_name}' 已開始在背景執行",
         script_name=script_name,
-        execution_mode="background"
+        execution_mode="background",
     )
+
 
 @router.post("/scripts/stop/{script_name}")
 async def stop_script(script_name: str):
@@ -197,36 +240,33 @@ async def stop_script(script_name: str):
     """
     if script_name not in running_scripts:
         raise HTTPException(
-            status_code=404,
-            detail=f"腳本 '{script_name}' 目前未在執行中"
+            status_code=404, detail=f"腳本 '{script_name}' 目前未在執行中"
         )
-    
+
     try:
         process = running_scripts[script_name]
         process.terminate()
-        
+
         # 等待進程結束，超時後強制終止
         try:
             process.wait(timeout=5)
         except subprocess.TimeoutExpired:
             process.kill()
             process.wait()
-        
+
         del running_scripts[script_name]
         logger.info(f"腳本 {script_name} 已停止")
-        
+
         return {
             "success": True,
             "message": f"腳本 '{script_name}' 已成功停止",
-            "script_name": script_name
+            "script_name": script_name,
         }
-        
+
     except Exception as e:
         logger.error(f"停止腳本時發生錯誤: {str(e)}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"停止腳本時發生錯誤: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"停止腳本時發生錯誤: {str(e)}")
+
 
 @router.post("/scripts/stop-all")
 async def stop_all_scripts():
@@ -237,44 +277,45 @@ async def stop_all_scripts():
         return {
             "success": True,
             "message": "目前沒有正在執行的腳本",
-            "stopped_scripts": []
+            "stopped_scripts": [],
         }
-    
+
     stopped_scripts = []
     failed_scripts = []
-    
+
     for script_name, process in list(running_scripts.items()):
         try:
             process.terminate()
-            
+
             # 等待進程結束，超時後強制終止
             try:
                 process.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait()
-            
+
             del running_scripts[script_name]
             stopped_scripts.append(script_name)
             logger.info(f"腳本 {script_name} 已停止")
-            
+
         except Exception as e:
             failed_scripts.append(f"{script_name}: {str(e)}")
             logger.error(f"停止腳本 {script_name} 時發生錯誤: {str(e)}")
-    
+
     if failed_scripts:
         return {
             "success": False,
             "message": f"部分腳本停止失敗",
             "stopped_scripts": stopped_scripts,
-            "failed_scripts": failed_scripts
+            "failed_scripts": failed_scripts,
         }
     else:
         return {
             "success": True,
             "message": f"成功停止 {len(stopped_scripts)} 個腳本",
-            "stopped_scripts": stopped_scripts
+            "stopped_scripts": stopped_scripts,
         }
+
 
 @router.get("/scripts/status")
 async def get_scripts_status():
@@ -283,87 +324,95 @@ async def get_scripts_status():
     """
     return {
         "running_scripts": list(running_scripts.keys()),
-        "total_running": len(running_scripts)
+        "total_running": len(running_scripts),
     }
 
-async def run_script_sync(script_path: Path, script_name: str) -> Dict:
+
+async def run_script_sync(
+    script_path: Path, script_name: str, args: Optional[List[str]] = None
+) -> Dict:
     """
     同步執行腳本
     """
     try:
         # 使腳本可執行
         os.chmod(script_path, 0o755)
-        
+
         # 執行腳本
+        cmd = ["bash", str(script_path)]
+        if args:
+            cmd.extend(args)
         process = await asyncio.create_subprocess_exec(
-            "bash", str(script_path),
+            *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            cwd=script_path.parent
+            cwd=script_path.parent,
         )
-        
+
         stdout, stderr = await process.communicate()
-        
+
         if process.returncode == 0:
             logger.info(f"腳本 {script_name} 執行完成")
             return {
                 "success": True,
                 "message": f"腳本 '{script_name}' 執行完成",
-                "stdout": stdout.decode('utf-8', errors='ignore'),
-                "stderr": stderr.decode('utf-8', errors='ignore')
+                "stdout": stdout.decode("utf-8", errors="ignore"),
+                "stderr": stderr.decode("utf-8", errors="ignore"),
             }
         else:
             logger.error(f"腳本 {script_name} 執行失敗，返回碼: {process.returncode}")
             return {
                 "success": False,
                 "message": f"腳本執行失敗，返回碼: {process.returncode}",
-                "stdout": stdout.decode('utf-8', errors='ignore'),
-                "stderr": stderr.decode('utf-8', errors='ignore')
+                "stdout": stdout.decode("utf-8", errors="ignore"),
+                "stderr": stderr.decode("utf-8", errors="ignore"),
             }
-            
+
     except Exception as e:
         logger.error(f"執行腳本時發生異常: {str(e)}")
-        return {
-            "success": False,
-            "message": f"執行腳本時發生異常: {str(e)}"
-        }
+        return {"success": False, "message": f"執行腳本時發生異常: {str(e)}"}
 
-def run_script_background(script_path: Path, script_name: str):
+
+def run_script_background(
+    script_path: Path, script_name: str, args: Optional[List[str]] = None
+):
     """
     背景執行腳本
     """
     try:
         # 使腳本可執行
         os.chmod(script_path, 0o755)
-        
+
         logger.info(f"開始背景執行腳本: {script_name}")
-        
+
         # 啟動進程
+        cmd = ["bash", str(script_path)]
+        if args:
+            cmd.extend(args)
         process = subprocess.Popen(
-            ["bash", str(script_path)],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=script_path.parent
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=script_path.parent
         )
-        
+
         # 記錄正在執行的腳本
         running_scripts[script_name] = process
-        
+
         # 等待進程完成
         stdout, stderr = process.communicate()
-        
+
         # 從執行列表中移除
         if script_name in running_scripts:
             del running_scripts[script_name]
-        
+
         if process.returncode == 0:
             logger.info(f"背景腳本 {script_name} 執行完成")
         else:
-            logger.error(f"背景腳本 {script_name} 執行失敗，返回碼: {process.returncode}")
+            logger.error(
+                f"背景腳本 {script_name} 執行失敗，返回碼: {process.returncode}"
+            )
             logger.error(f"錯誤輸出: {stderr.decode('utf-8', errors='ignore')}")
-            
+
     except Exception as e:
         logger.error(f"背景執行腳本時發生異常: {str(e)}")
         # 確保從執行列表中移除
         if script_name in running_scripts:
-            del running_scripts[script_name] 
+            del running_scripts[script_name]

--- a/prototype/frontend/src/App.tsx
+++ b/prototype/frontend/src/App.tsx
@@ -21,6 +21,8 @@ import { RealtimeSchedulePanel } from './components/RealtimeSchedulePanel'
 import { RealtimeStatusIndicator, RealtimeStatusBadge } from './components/RealtimeStatusIndicator'
 import { usePerformanceMetrics } from './hooks/usePerformanceMetrics'
 import { useRealtimeScheduler } from './hooks/useRealtimeScheduler'
+import { useAutoplayScheduler, AutoplayOptions } from './hooks/useAutoplayScheduler'
+import { getActiveMode } from './utils/mode'
 
 // 引入服務
 import { 
@@ -151,45 +153,73 @@ function App() {
   // 使用排程器 (全域唯一)
   const realtimeScheduler = useRealtimeScheduler();
 
+  // 解析模式與參數
+  const { mode: activeMode, conflict } = getActiveMode(window.location.search);
+  const urlParams = new URLSearchParams(window.location.search);
+  const isAutoplayMode = activeMode === 'autoplay';
+  const autoStart = activeMode === 'autostart' ||
+                    (activeMode === null && window.location.hostname !== 'localhost');
+
+  const autoplayOptions = React.useMemo<AutoplayOptions | null>(() => {
+    if (!isAutoplayMode) return null;
+    const startAtParam = urlParams.get('startAt');
+    const countParam = urlParams.get('count');
+    let startAt = new Date();
+    if (startAtParam) {
+      if (/^\d{2}:\d{2}$/.test(startAtParam)) {
+        const [h, m] = startAtParam.split(':').map(Number);
+        startAt.setHours(h, m, 0, 0);
+        if (startAt.getTime() < Date.now()) {
+          startAt.setDate(startAt.getDate() + 1);
+        }
+      } else {
+        const parsed = new Date(startAtParam);
+        if (!isNaN(parsed.getTime())) startAt = parsed;
+      }
+    }
+    const count = countParam ? parseInt(countParam, 10) : undefined;
+    return { startAt, count };
+  }, [isAutoplayMode, urlParams]);
+
+  useAutoplayScheduler(autoplayOptions);
+
+  useEffect(() => {
+    if (conflict) {
+      toast('autoplay 與 autostart 同時存在，將以 autoplay 為主');
+    }
+  }, [conflict]);
+
   // === 自動初始化 Happy Path ===
   useEffect(() => {
-    // 檢查是否應該啟用自動初始化（通過 URL 參數或簡化條件）
-    const urlParams = new URLSearchParams(window.location.search);
-    const autoStart = urlParams.get('autostart') === 'true' || 
-                      window.location.hostname !== 'localhost'; // 非本地環境下預設啟用
-    
+    if (isAutoplayMode) {
+      return;
+    }
     if (!autoStart) {
       console.log('[App] Auto-start disabled, skipping happy path initialization');
       return;
     }
 
-    // 頁面載入後 3 秒自動啟用排程模式並隱藏按鈕
     const initTimer = setTimeout(() => {
       console.log('[App] Auto-initializing happy path...');
-      
-      // 1. 啟用排程模式
+
       useStore.getState().setScheduleEnabled(true);
       console.log('[App] ✅ Schedule enabled');
-      
-      // 2. 隱藏右側按鈕（只有在顯示時才隱藏）
+
       if (useStore.getState().isSideButtonsVisible) {
         useStore.getState().toggleSideButtons();
         console.log('[App] ✅ Side buttons hidden');
       }
-      
-      // 3. 確保不是手動模式
+
       if (useStore.getState().isManualMode) {
         useStore.getState().disableManualMode();
         console.log('[App] ✅ Manual mode disabled');
       }
-      
-      // 全螢幕模式由 AppleScript 腳本處理
-      
+
       console.log('[App] 🚀 Happy path initialized - Schedule running with hidden UI');
-    }, 3000); // 3秒後執行
+    }, 3000);
 
     return () => clearTimeout(initTimer);
-  }, []); // 只在組件掛載時執行一次
+  }, [autoStart, isAutoplayMode]);
 
   // 監聽 realtimeStreaming 狀態變化，同步到排程系統（避免循環更新）
   useEffect(() => {

--- a/prototype/frontend/src/hooks/useAutoplayScheduler.ts
+++ b/prototype/frontend/src/hooks/useAutoplayScheduler.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+import { useStore } from '../store';
+
+export interface AutoplayOptions {
+  startAt: Date;
+  interval?: number; // seconds
+  count?: number;
+}
+
+export function useAutoplayScheduler(options: AutoplayOptions | null): void {
+  const {
+    setAutoplayEnabled,
+    setNextTrigger,
+    setIntervalSeconds,
+    resetAutoplay,
+  } = useStore((state) => ({
+    setAutoplayEnabled: state.setAutoplayEnabled,
+    setNextTrigger: state.setNextTrigger,
+    setIntervalSeconds: state.setIntervalSeconds,
+    resetAutoplay: state.resetAutoplay,
+  }));
+
+  const timeoutRef = useRef<number>();
+  const intervalRef = useRef<number>();
+
+  useEffect(() => {
+    if (!options) {
+      resetAutoplay();
+      return;
+    }
+
+    const { startAt, interval, count } = options;
+    const delay = startAt.getTime() - Date.now();
+
+    setAutoplayEnabled(true);
+    setNextTrigger(startAt.getTime());
+    if (interval) {
+      setIntervalSeconds(interval);
+    }
+
+    const trigger = () => {
+      fetch('/api/scripts/execute/random-yoga', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(count !== undefined ? { count } : {}),
+      }).catch((err) => console.error('autoplay request failed', err));
+    };
+
+    timeoutRef.current = window.setTimeout(() => {
+      trigger();
+      if (interval) {
+        intervalRef.current = window.setInterval(trigger, interval * 1000);
+      } else {
+        resetAutoplay();
+      }
+    }, Math.max(0, delay));
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+      resetAutoplay();
+    };
+  }, [options, setAutoplayEnabled, setNextTrigger, setIntervalSeconds, resetAutoplay]);
+}

--- a/prototype/frontend/src/store/index.ts
+++ b/prototype/frontend/src/store/index.ts
@@ -16,6 +16,7 @@ import { RuntimeSlice, createRuntimeSlice } from './slices/runtimeSlice';
 import { RoomSlice, createRoomSlice } from './slices/roomSlice';
 import { createDanceSlice, DanceSlice } from './slices/danceSlice';
 import { RealtimeScheduleSlice, createRealtimeScheduleSlice } from './slices/realtimeScheduleSlice';
+import { AutoplayScheduleSlice, createAutoplayScheduleSlice } from './slices/autoplayScheduleSlice';
 // import { EmotionSlice, createEmotionSlice } from './slices/emotionSlice';
 // import { AudioSlice, createAudioSlice } from './slices/audioSlice';
 
@@ -34,7 +35,8 @@ export type AppState =
   RuntimeSlice &
   RoomSlice &
   DanceSlice &
-  RealtimeScheduleSlice;
+  RealtimeScheduleSlice &
+  AutoplayScheduleSlice;
 
 // 創建 Zustand Store
 export const useStore = create<AppState>()(
@@ -54,6 +56,7 @@ export const useStore = create<AppState>()(
       ...createRoomSlice(...a),
       ...createDanceSlice(...a),
       ...createRealtimeScheduleSlice(...a),
+      ...createAutoplayScheduleSlice(...a),
     }),
     { name: 'AppStore' } // Optional: Name for Redux DevTools
   )

--- a/prototype/frontend/src/store/slices/autoplayScheduleSlice.ts
+++ b/prototype/frontend/src/store/slices/autoplayScheduleSlice.ts
@@ -1,0 +1,21 @@
+import { StateCreator } from 'zustand';
+
+export interface AutoplayScheduleSlice {
+  autoplayEnabled: boolean;
+  nextTrigger: number | null;
+  intervalSeconds: number | null;
+  setAutoplayEnabled: (enabled: boolean) => void;
+  setNextTrigger: (ts: number | null) => void;
+  setIntervalSeconds: (secs: number | null) => void;
+  resetAutoplay: () => void;
+}
+
+export const createAutoplayScheduleSlice: StateCreator<AutoplayScheduleSlice> = (set) => ({
+  autoplayEnabled: false,
+  nextTrigger: null,
+  intervalSeconds: null,
+  setAutoplayEnabled: (enabled) => set({ autoplayEnabled: enabled }),
+  setNextTrigger: (ts) => set({ nextTrigger: ts }),
+  setIntervalSeconds: (secs) => set({ intervalSeconds: secs }),
+  resetAutoplay: () => set({ autoplayEnabled: false, nextTrigger: null, intervalSeconds: null }),
+});

--- a/prototype/frontend/src/utils/mode.test.ts
+++ b/prototype/frontend/src/utils/mode.test.ts
@@ -1,0 +1,15 @@
+import { getActiveMode } from './mode';
+
+describe('getActiveMode', () => {
+  it('prefers autoplay when both modes provided', () => {
+    const res = getActiveMode('?mode=autoplay&autostart=true');
+    expect(res.mode).toBe('autoplay');
+    expect(res.conflict).toBe(true);
+  });
+
+  it('returns autostart when only autostart provided', () => {
+    const res = getActiveMode('?mode=autostart');
+    expect(res.mode).toBe('autostart');
+    expect(res.conflict).toBe(false);
+  });
+});

--- a/prototype/frontend/src/utils/mode.ts
+++ b/prototype/frontend/src/utils/mode.ts
@@ -1,0 +1,17 @@
+export type Mode = 'autostart' | 'autoplay' | null;
+
+export interface ModeResult {
+  mode: Mode;
+  conflict: boolean;
+}
+
+export function getActiveMode(search: string): ModeResult {
+  const params = new URLSearchParams(search);
+  const modeParam = params.get('mode');
+  const legacyAutostart = params.get('autostart') === 'true';
+  const hasAutoplay = modeParam === 'autoplay';
+  const hasAutostart = modeParam === 'autostart' || legacyAutostart;
+  const conflict = hasAutoplay && hasAutostart && modeParam !== 'autoplay';
+  const mode: Mode = hasAutoplay ? 'autoplay' : hasAutostart ? 'autostart' : null;
+  return { mode, conflict };
+}


### PR DESCRIPTION
## Summary
- support script arguments and optional count for random yoga API
- implement front-end autoplay mode with scheduled random yoga trigger
- document new script execution features

## Testing
- `PYENV_VERSION=3.10.17 isort api/endpoints/scripts.py`
- `PYENV_VERSION=3.10.17 black api/endpoints/scripts.py`
- `PYENV_VERSION=3.10.17 mypy api/endpoints/scripts.py` *(fails: missing dependencies)*
- `PYENV_VERSION=3.10.17 pytest` *(fails: ModuleNotFoundError: google)*
- `npm run lint` *(fails: many lint errors)*
- `npm test` *(fails: react-scripts not found)*
- `npx markdownlint "**/*.md" --ignore node_modules` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bda47963a88321b4e45f49fa1b178b